### PR TITLE
geolocation updated

### DIFF
--- a/app/src/main/java/com/monkeyteam/chimpagne/model/location/Nominatim.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/location/Nominatim.kt
@@ -11,64 +11,89 @@ import okhttp3.Response
 import org.json.JSONArray
 
 object NominatimConstants {
-  const val SCHEME = "https"
-  const val HOST = "nominatim.openstreetmap.org"
+    const val SCHEME = "https"
+    const val HOST = "nominatim.openstreetmap.org"
 }
 
 fun convertNameToLocations(name: String, onResult: (List<Location>) -> Unit, limit: Int = 5) {
+    val client = OkHttpClient()
 
-  val client = OkHttpClient()
+    val url = HttpUrl.Builder()
+        .scheme(NominatimConstants.SCHEME)
+        .host(NominatimConstants.HOST)
+        .addPathSegment("search.php")
+        .addQueryParameter("q", java.net.URLEncoder.encode(name, "UTF-8"))
+        .addQueryParameter("format", "jsonv2")
+        .addQueryParameter("addressdetails", "1")
+        .addQueryParameter("limit", limit.toString())
+        .build()
 
-  val url =
-      HttpUrl.Builder()
-          .scheme(NominatimConstants.SCHEME)
-          .host(NominatimConstants.HOST)
-          .addPathSegment("search.php")
-          .addQueryParameter("q", java.net.URLEncoder.encode(name, "UTF-8"))
-          .addQueryParameter("format", "jsonv2")
-          .addQueryParameter("limit", limit.toString())
-          .build()
+    val request = Request.Builder().url(url).addHeader("User-Agent", "Chimpagne").build()
+    client.newCall(request).enqueue(object : Callback {
+        override fun onFailure(call: Call, e: IOException) {
+            Log.e("LocationHelper", "Failed to get location for $name, because of IO Exception", e)
+            onResult(listOf())
+        }
 
-  val request = Request.Builder().url(url).addHeader("User-Agent", "Chimpagne").build()
-  client
-      .newCall(request)
-      .enqueue(
-          object : Callback {
-
-            override fun onFailure(call: Call, e: IOException) {
-              Log.e(
-                  "LocationHelper", "Failed to get location for $name, because of IO Exception", e)
-              onResult(listOf())
-            }
-
-            override fun onResponse(call: Call, response: Response) {
-              response.use {
+        override fun onResponse(call: Call, response: Response) {
+            response.use {
                 if (!response.isSuccessful) {
-                  Log.e(
-                      "LocationHelper",
-                      "Failed to get location for $name, because of unsuccessful response")
-                  onResult(listOf())
-                } else {
-                  val geoLocation = response.body?.string()
-                  val jsonArray = geoLocation?.let { JSONArray(it) }
-                  if (jsonArray != null && jsonArray.length() > 0) {
-                    val locations = arrayListOf<Location>()
-                    for (i in 0 ..< jsonArray.length()) {
-                      val jsonObject = jsonArray.getJSONObject(i)
-                      val locName = jsonObject.getString("display_name")
-                      val lat = jsonObject.getDouble("lat")
-                      val lon = jsonObject.getDouble("lon")
-                      locations.add(Location(locName, lat, lon))
-                    }
-                    onResult(locations)
-                  } else {
-                    Log.e(
-                        "LocationHelper",
-                        "Failed to get location for $name, because of empty response")
+                    Log.e("LocationHelper", "Failed to get location for $name, because of unsuccessful response")
                     onResult(listOf())
-                  }
+                } else {
+                    val jsonString = response.body?.string()
+                    val jsonArray = jsonString?.let { JSONArray(it) }
+                    val uniqueDisplayNames = mutableSetOf<String>()
+                    val locations = mutableListOf<Location>()
+
+                    if (jsonArray != null) {
+                        for (i in 0 until jsonArray.length()) {
+                            val jsonObject = jsonArray.getJSONObject(i)
+                            val addressObject = jsonObject.getJSONObject("address")
+                            val category = jsonObject.optString("category", "")
+                            val country = addressObject.optString("country", "")
+                            val normalizedCountry = if (country == "Schweiz/Suisse/Svizzera/Svizra") "Switzerland" else country
+
+                            val displayName = when {
+                                category == "building" -> {
+                                    val road = addressObject.optString("road", "")
+                                    val houseNumber = addressObject.optString("house_number", "")
+                                    val postcode = addressObject.optString("postcode", "")
+                                    val village = addressObject.optString("village", addressObject.optString("town", addressObject.optString("city", "")))
+                                    "$road $houseNumber, $postcode, $village, $normalizedCountry"
+                                }
+                                category == "amenity" -> {
+                                    val amenity = addressObject.optString("amenity", "")
+                                    val locality = addressObject.optString("city", addressObject.optString("town", addressObject.optString("village", "")))
+                                    val postcode = addressObject.optString("postcode", "")
+                                    "$amenity, $locality, $postcode, $normalizedCountry"
+                                }
+                                else -> {
+                                    val specificCategoryValue = addressObject.optString(category, "")
+                                    val locality = addressObject.optString("city", addressObject.optString("town", addressObject.optString("village", "")))
+                                    val postcode = addressObject.optString("postcode", "")
+                                    if (specificCategoryValue.isNotEmpty()) "$specificCategoryValue, $category, $locality, $postcode, $normalizedCountry"
+                                    else "$locality, $postcode, $normalizedCountry"
+                                }
+                            }
+
+                            // Deduplication based on display name
+                            if (uniqueDisplayNames.add(displayName)) {
+                                val lat = jsonObject.getDouble("lat")
+                                val lon = jsonObject.getDouble("lon")
+                                locations.add(Location(displayName, lat, lon))
+                            }
+                        }
+                    }
+
+                    if (locations.isNotEmpty()) {
+                        onResult(locations)
+                    } else {
+                        Log.e("LocationHelper", "No unique locations found for $name")
+                        onResult(listOf())
+                    }
                 }
-              }
             }
-          })
+        }
+    })
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/LocationSelector.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/LocationSelector.kt
@@ -1,15 +1,23 @@
 package com.monkeyteam.chimpagne.ui.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -17,7 +25,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.location.Location
 import com.monkeyteam.chimpagne.model.location.convertNameToLocations
@@ -32,46 +42,77 @@ fun LocationSelector(
 
   var locationQuery by remember { mutableStateOf(selectedLocation?.name ?: "") }
   var searching by remember { mutableStateOf(false) }
-  var showSearchBar by remember { mutableStateOf(false) }
+    var showSearchBar by remember { mutableStateOf(false) }
+  var searchCompleted by remember { mutableStateOf(false) }
   var possibleLocations by remember { mutableStateOf(emptyList<Location>()) }
 
   val launchSearch = {
     searching = true
-    showSearchBar = false
+      showSearchBar = true
     convertNameToLocations(
         locationQuery,
         {
           possibleLocations = it
           searching = false
-          if (it.isNotEmpty()) showSearchBar = true
+          searchCompleted = it.isNotEmpty()
         },
         10)
   }
 
-  DockedSearchBar(
+    val clearLocationInput = {
+        locationQuery = ""
+        possibleLocations = emptyList()
+        searchCompleted = false
+        updateSelectedLocation(Location())
+    }
+
+
+    DockedSearchBar(
       query = locationQuery,
-      onQueryChange = { if (!searching) locationQuery = it },
+      onQueryChange = {
+          locationQuery = it
+          searchCompleted= false
+      },
       onSearch = { launchSearch() },
       active = showSearchBar,
-      onActiveChange = {},
+      onActiveChange = { showSearchBar = it},
       placeholder = { Text(stringResource(id = R.string.search_location)) },
       modifier = modifier,
-      trailingIcon = {
-        IconButton(onClick = launchSearch) {
-          if (!searching) Icon(imageVector = Icons.Default.Search, contentDescription = "Search")
-          else CircularProgressIndicator()
+        trailingIcon = {
+            when {
+                searching -> CircularProgressIndicator()
+                locationQuery.isNotEmpty() && searchCompleted -> IconButton(onClick = clearLocationInput) {
+                    Icon(imageVector = Icons.Default.Clear, contentDescription = "Clear")
+                }
+                locationQuery.isNotEmpty() && !searchCompleted -> IconButton(onClick = launchSearch) {
+                    Icon(imageVector = Icons.Default.Search, contentDescription = "Search")
+                }
+            }
+        }) {
+        if(possibleLocations.isNotEmpty()) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(8.dp), // Set a rounded corner shape
+                color = MaterialTheme.colorScheme.surface
+            ) {
+                LazyColumn {
+                    items(possibleLocations) { location ->
+                        Text(
+                            text = location.name,
+                            modifier = Modifier
+                                .clickable {
+                                    locationQuery = location.name
+                                    searchCompleted = true
+                                    showSearchBar = false
+                                    updateSelectedLocation(location)
+                                }
+                                .fillMaxWidth()
+                                .padding(16.dp)
+                        )
+                        HorizontalDivider(color = Color.LightGray)
+                    }
+                }
+            }
         }
-      }) {
-        LazyColumn {
-          items(possibleLocations) { location ->
-            Text(
-                location.name,
-                Modifier.clickable {
-                  locationQuery = location.name
-                  showSearchBar = false
-                  updateSelectedLocation(location)
-                })
-          }
-        }
-      }
+    }
 }


### PR DESCRIPTION
I've refined the geolocation features within `Nominatim.kt` and `LocationSelector.kt` to enhance user interaction and data presentation. The LazyColumn now neatly displays up to five search results, each distinctly bounded for improved clarity. Addressing the JSON response variability was a significant challenge, as the returned data's format could vary widely based on the user's query. There was no straightforward, all-encompassing method to selectively display only the relevant attributes since they might or might not be present in the response from the Nominatim API. However, I devised tailored solutions for different scenarios, leading to a codebase that's not only more readable but also more maintainable. Additionally, I've implemented a feature for easy clearing of the location input, which streamlines the user experience by eliminating the previous, annoying manual process.