### PR TITLE
geolocation updated

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,7 +83,7 @@ dependencies {
     implementation(libs.maps.compose)
 
     testImplementation(libs.junit)
-    testImplementation(libs.mockwebserver)
+    implementation(libs.mockwebserver)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -103,6 +103,10 @@ dependencies {
     implementation(libs.maps.compose)
 
     implementation(libs.coil.compose)
+
+    // For testing the locationSelector
+    implementation(libs.mockito.core)
+    implementation(libs.mockito.inline)
 
 }
 

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/EventCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/EventCreationScreenTest.kt
@@ -1,17 +1,26 @@
 package com.monkeyteam.chimpagne
 
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.navigation.compose.rememberNavController
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.matcher.ViewMatchers.withTagValue
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.monkeyteam.chimpagne.ui.EventCreationScreen
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
+import org.hamcrest.CoreMatchers.`is`
 import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
@@ -32,7 +41,7 @@ class EventCreationScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   @Test
-  fun TestPanels() {
+  fun testPanels() {
     // Start on the correct screen
     composeTestRule.setContent {
       val navController = rememberNavController()
@@ -53,6 +62,19 @@ class EventCreationScreenTest {
   }
 
   @Test
+  fun testLocationSelector() {
+    // Start on the correct screen
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navActions = NavigationActions(navController)
+      EventCreationScreen(0, navActions)
+    }
+
+    composeTestRule.onNodeWithTag("LocationComponent").assertIsDisplayed()
+
+  }
+
+    @Test
   fun testPanel1() {
 
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/LocationSelectorTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/LocationSelectorTests.kt
@@ -1,13 +1,25 @@
 package com.monkeyteam.chimpagne
 
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.printToLog
 import com.monkeyteam.chimpagne.model.location.NominatimConstants
 import com.monkeyteam.chimpagne.model.location.convertNameToLocations
+import com.monkeyteam.chimpagne.ui.components.LocationSelector
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -16,6 +28,8 @@ import java.util.concurrent.TimeUnit
 class LocationSelectorTest {
 
     private lateinit var server: MockWebServer
+
+    //BACKEND tests
 
     @Before
     fun setUp() {
@@ -26,7 +40,6 @@ class LocationSelectorTest {
         NominatimConstants.PORT = url.port
         NominatimConstants.SCHEME = url.scheme
     }
-
 
     @After
     fun tearDown() {
@@ -49,6 +62,71 @@ class LocationSelectorTest {
 
         assertTrue("Callback was not invoked within the timeout period", latch.await(2, TimeUnit.SECONDS))
     }
+
+    @Test
+    fun testCategoryBuilding() {
+        val json = """[{
+        "place_id": 123,
+        "category": "building",
+        "type": "office",
+        "address": {
+            "country": "USA",
+            "postcode": "90210",
+            "city": "Beverly Hills",
+            "road": "Wilshire Boulevard",
+            "house_number": "123",
+            "building": "Empire State"
+        },
+        "lat": "34.069",
+        "lon": "-118.406"
+    }]"""
+
+        server.enqueue(MockResponse().setBody(json).setResponseCode(200))
+        val latch = CountDownLatch(1)
+
+        convertNameToLocations("Empire State", { locations ->
+            assertTrue(locations.isNotEmpty())
+            assertEquals("Wilshire Boulevard 123, 90210, Beverly Hills, USA", locations.first().name)
+            assertEquals(34.069, locations.first().latitude, 0.001)
+            assertEquals(-118.406, locations.first().longitude, 0.001)
+            latch.countDown()
+        }, 1)
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun testCategoryAmenity() {
+        val json = """[{
+        "place_id": 456,
+        "category": "amenity",
+        "type": "university",
+        "address": {
+            "country": "Schweiz/Suisse/Svizzera/Svizra",
+            "postcode": "1015",
+            "city": "Lausanne",
+            "road": "Route de la Sorge",
+            "amenity": "EPFL"
+        },
+        "lat": "46.519",
+        "lon": "6.566"
+    }]"""
+
+        server.enqueue(MockResponse().setBody(json).setResponseCode(200))
+        val latch = CountDownLatch(1)
+
+        convertNameToLocations("EPFL", { locations ->
+            assertTrue("Expected non-empty list of locations", locations.isNotEmpty())
+            assertEquals("EPFL, Lausanne, 1015, Switzerland", locations.first().name)
+            assertEquals(46.519, locations.first().latitude, 0.001)
+            assertEquals(6.566, locations.first().longitude, 0.001)
+            latch.countDown()
+        }, limit = 5)
+
+        assertTrue("Callback was not invoked within the timeout period", latch.await(2, TimeUnit.SECONDS))
+    }
+
+
 
     @Test
     fun testApiResponseFailure() {

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/LocationSelectorTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/LocationSelectorTests.kt
@@ -1,0 +1,78 @@
+package com.monkeyteam.chimpagne
+
+import com.monkeyteam.chimpagne.model.location.NominatimConstants
+import com.monkeyteam.chimpagne.model.location.convertNameToLocations
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+
+class LocationSelectorTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val url = server.url("/")
+        NominatimConstants.HOST = url.host
+        NominatimConstants.PORT = url.port
+        NominatimConstants.SCHEME = url.scheme
+    }
+
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        NominatimConstants.HOST = "nominatim.openstreetmap.org"
+    }
+
+    @Test
+    fun testSuccessfulResponse() {
+        val json = """[{"lat": 52.5200, "lon": 13.4050, "address": {"country": "Germany", "city": "Berlin"}, "category": "city"}]"""
+        server.enqueue(MockResponse().setBody(json).setResponseCode(200))
+        val latch = CountDownLatch(1)
+
+        convertNameToLocations("Berlin", { locations ->
+            assertTrue("Expected non-empty list of locations", locations.isNotEmpty())
+            assertEquals("Latitude should match", 52.5200, locations.first().latitude, 0.001)
+            assertEquals("Longitude should match", 13.4050, locations.first().longitude, 0.001)
+            latch.countDown()
+        }, limit = 5)
+
+        assertTrue("Callback was not invoked within the timeout period", latch.await(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun testApiResponseFailure() {
+        server.enqueue(MockResponse().setResponseCode(500)) // Simulate API failure
+        val latch = CountDownLatch(1)
+
+        convertNameToLocations("Invalid", { locations ->
+            assertTrue("Expected empty locations list on API failure", locations.isEmpty())
+            latch.countDown()
+        }, limit = 5)
+
+        assertTrue("Test timed out waiting for callback", latch.await(5, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun testNetworkFailure() {
+        server.shutdown() // Immediately shut down to simulate a network failure
+        val latch = CountDownLatch(1)
+
+        convertNameToLocations("Shutdown", { locations ->
+            assertTrue("The locations list should be empty when there is a network failure", locations.isEmpty())
+            latch.countDown()
+        }, 5)
+
+        assertTrue("Callback was not invoked within the timeout period", latch.await(2, TimeUnit.SECONDS))
+    }
+}

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/LocationSelectorTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/LocationSelectorTests.kt
@@ -75,4 +75,34 @@ class LocationSelectorTest {
 
         assertTrue("Callback was not invoked within the timeout period", latch.await(2, TimeUnit.SECONDS))
     }
+
+    @Test
+    fun testEmptyResponse() {
+        val json = "[]"
+        server.enqueue(MockResponse().setBody(json).setResponseCode(200))
+        val latch = CountDownLatch(1)
+
+        convertNameToLocations("EmptyResponse", { locations ->
+            assertTrue("Expected an empty list of locations", locations.isEmpty())
+            latch.countDown()
+        }, limit = 5)
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun testInvalidJsonResponse() {
+        val invalidJson = "Not a JSON"
+        server.enqueue(MockResponse().setBody(invalidJson).setResponseCode(200))
+        val latch = CountDownLatch(1)
+
+        convertNameToLocations("InvalidJSON", { locations ->
+            assertTrue("Expected an empty list of locations due to invalid JSON", locations.isEmpty())
+            latch.countDown()
+        }, limit = 5)
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+    }
+
 }
+

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/LocationSelectorTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/LocationSelectorTests.kt
@@ -86,7 +86,7 @@ class LocationSelectorTest {
 
         convertNameToLocations("Empire State", { locations ->
             assertTrue(locations.isNotEmpty())
-            assertEquals("Wilshire Boulevard 123, 90210, Beverly Hills, USA", locations.first().name)
+            assertEquals("Wilshire Boulevard, 123, 90210, Beverly Hills, USA", locations.first().name)
             assertEquals(34.069, locations.first().latitude, 0.001)
             assertEquals(-118.406, locations.first().longitude, 0.001)
             latch.countDown()

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/LocationTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/LocationTests.kt
@@ -1,31 +1,19 @@
 package com.monkeyteam.chimpagne
 
-import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextInput
-import androidx.compose.ui.test.printToLog
 import com.monkeyteam.chimpagne.model.location.NominatimConstants
 import com.monkeyteam.chimpagne.model.location.convertNameToLocations
-import com.monkeyteam.chimpagne.ui.components.LocationSelector
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 
-class LocationSelectorTest {
+class LocationTests {
 
     private lateinit var server: MockWebServer
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Chimpagne"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
 
         <meta-data
@@ -20,7 +21,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.Chimpagne">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/location/Nominatim.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/location/Nominatim.kt
@@ -44,6 +44,11 @@ fun convertNameToLocations(name: String, onResult: (List<Location>) -> Unit, lim
                     onResult(listOf())
                 } else {
                     val jsonString = response.body?.string()
+                    if (jsonString.isNullOrEmpty() || !jsonString.startsWith("[")) {
+                        Log.e("LocationHelper", "Invalid JSON response")
+                        onResult(listOf())
+                        return
+                    }
                     val jsonArray = jsonString?.let { JSONArray(it) }
                     val uniqueDisplayNames = mutableSetOf<String>()
                     val locations = mutableListOf<Location>()
@@ -51,7 +56,7 @@ fun convertNameToLocations(name: String, onResult: (List<Location>) -> Unit, lim
                     if (jsonArray != null) {
                         for (i in 0 until jsonArray.length()) {
                             val jsonObject = jsonArray.getJSONObject(i)
-                            val addressObject = jsonObject.getJSONObject("address")
+                            val addressObject = jsonObject.optJSONObject("address") ?: continue
                             val category = jsonObject.optString("category", "")
                             val country = addressObject.optString("country", "")
                             val normalizedCountry = if (country == "Schweiz/Suisse/Svizzera/Svizra") "Switzerland" else country

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/location/Nominatim.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/location/Nominatim.kt
@@ -49,48 +49,81 @@ fun convertNameToLocations(name: String, onResult: (List<Location>) -> Unit, lim
                         onResult(listOf())
                         return
                     }
-                    val jsonArray = jsonString?.let { JSONArray(it) }
+                    val jsonArray = JSONArray(jsonString)
                     val uniqueDisplayNames = mutableSetOf<String>()
                     val locations = mutableListOf<Location>()
 
-                    if (jsonArray != null) {
-                        for (i in 0 until jsonArray.length()) {
-                            val jsonObject = jsonArray.getJSONObject(i)
-                            val addressObject = jsonObject.optJSONObject("address") ?: continue
-                            val category = jsonObject.optString("category", "")
-                            val country = addressObject.optString("country", "")
-                            val normalizedCountry = if (country == "Schweiz/Suisse/Svizzera/Svizra") "Switzerland" else country
+                    for (i in 0 until jsonArray.length()) {
+                        val jsonObject = jsonArray.getJSONObject(i)
+                        val addressObject = jsonObject.optJSONObject("address") ?: continue
+                        val category = jsonObject.optString("category", "")
+                        val country = addressObject.optString("country", "")
+                        val normalizedCountry = if (country == "Schweiz/Suisse/Svizzera/Svizra") "Switzerland" else country
 
-                            val displayName = when {
-                                category == "building" -> {
-                                    val road = addressObject.optString("road", "")
-                                    val houseNumber = addressObject.optString("house_number", "")
-                                    val postcode = addressObject.optString("postcode", "")
-                                    val village = addressObject.optString("village", addressObject.optString("town", addressObject.optString("city", "")))
-                                    "$road $houseNumber, $postcode, $village, $normalizedCountry"
-                                }
-                                category == "amenity" -> {
-                                    val amenity = addressObject.optString("amenity", "")
-                                    val locality = addressObject.optString("city", addressObject.optString("town", addressObject.optString("village", "")))
-                                    val postcode = addressObject.optString("postcode", "")
-                                    "$amenity, $locality, $postcode, $normalizedCountry"
-                                }
-                                else -> {
-                                    val specificCategoryValue = addressObject.optString(category, "")
-                                    val locality = addressObject.optString("city", addressObject.optString("town", addressObject.optString("village", "")))
-                                    val postcode = addressObject.optString("postcode", "")
-                                    if (specificCategoryValue.isNotEmpty()) "$specificCategoryValue, $category, $locality, $postcode, $normalizedCountry"
-                                    else "$locality, $postcode, $normalizedCountry"
-                                }
+                        val displayName = when (category) {
+                            "building" -> {
+                                val components = listOfNotNull(
+                                    addressObject.optString("road", "").takeIf { it.isNotEmpty() },
+                                    addressObject.optString("house_number", "")
+                                        .takeIf { it.isNotEmpty() },
+                                    addressObject.optString("postcode", "")
+                                        .takeIf { it.isNotEmpty() },
+                                    addressObject.optString(
+                                        "village",
+                                        addressObject.optString(
+                                            "town",
+                                            addressObject.optString("city", "")
+                                        )
+                                    ).takeIf { it.isNotEmpty() },
+                                    normalizedCountry.takeIf { it.isNotEmpty() }
+                                )
+
+                                components.joinToString(", ")
                             }
+                            "amenity" -> {
+                                val components = listOfNotNull(
+                                    addressObject.optString("amenity", "")
+                                        .takeIf { it.isNotEmpty() },
+                                    addressObject.optString(
+                                        "city",
+                                        addressObject.optString(
+                                            "town",
+                                            addressObject.optString("village", "")
+                                        )
+                                    ).takeIf { it.isNotEmpty() },
+                                    addressObject.optString("postcode", "")
+                                        .takeIf { it.isNotEmpty() },
+                                    normalizedCountry.takeIf { it.isNotEmpty() }
+                                )
 
-                            // Deduplication based on display name
-                            if (uniqueDisplayNames.add(displayName)) {
-                                val lat = jsonObject.getDouble("lat")
-                                val lon = jsonObject.getDouble("lon")
-                                locations.add(Location(displayName, lat, lon))
+                                components.joinToString(", ")
+                            }
+                            else -> {
+                                val components = listOfNotNull(
+                                    addressObject.optString(category, "")
+                                        .takeIf { it.isNotEmpty() },
+                                    addressObject.optString(
+                                        "city",
+                                        addressObject.optString(
+                                            "town",
+                                            addressObject.optString("village", "")
+                                        )
+                                    ).takeIf { it.isNotEmpty() },
+                                    addressObject.optString("postcode", "")
+                                        .takeIf { it.isNotEmpty() },
+                                    normalizedCountry.takeIf { it.isNotEmpty() }
+                                )
+
+                                components.joinToString(", ")
                             }
                         }
+
+                        if (uniqueDisplayNames.add(displayName)) {
+                            val lat = jsonObject.getDouble("lat")
+                            val lon = jsonObject.getDouble("lon")
+                            locations.add(Location(displayName, lat, lon))
+                        }
+
                     }
 
                     if (locations.isNotEmpty()) {

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/location/Nominatim.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/location/Nominatim.kt
@@ -11,8 +11,9 @@ import okhttp3.Response
 import org.json.JSONArray
 
 object NominatimConstants {
-    const val SCHEME = "https"
-    const val HOST = "nominatim.openstreetmap.org"
+    var SCHEME = "https"
+    var HOST = "nominatim.openstreetmap.org"
+    var PORT = 443
 }
 
 fun convertNameToLocations(name: String, onResult: (List<Location>) -> Unit, limit: Int = 5) {
@@ -21,6 +22,7 @@ fun convertNameToLocations(name: String, onResult: (List<Location>) -> Unit, lim
     val url = HttpUrl.Builder()
         .scheme(NominatimConstants.SCHEME)
         .host(NominatimConstants.HOST)
+        .port(NominatimConstants.PORT)
         .addPathSegment("search.php")
         .addQueryParameter("q", java.net.URLEncoder.encode(name, "UTF-8"))
         .addQueryParameter("format", "jsonv2")

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/location/Nominatim.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/location/Nominatim.kt
@@ -11,64 +11,89 @@ import okhttp3.Response
 import org.json.JSONArray
 
 object NominatimConstants {
-  const val SCHEME = "https"
-  const val HOST = "nominatim.openstreetmap.org"
+    const val SCHEME = "https"
+    const val HOST = "nominatim.openstreetmap.org"
 }
 
 fun convertNameToLocations(name: String, onResult: (List<Location>) -> Unit, limit: Int = 5) {
+    val client = OkHttpClient()
 
-  val client = OkHttpClient()
+    val url = HttpUrl.Builder()
+        .scheme(NominatimConstants.SCHEME)
+        .host(NominatimConstants.HOST)
+        .addPathSegment("search.php")
+        .addQueryParameter("q", java.net.URLEncoder.encode(name, "UTF-8"))
+        .addQueryParameter("format", "jsonv2")
+        .addQueryParameter("addressdetails", "1")
+        .addQueryParameter("limit", limit.toString())
+        .build()
 
-  val url =
-      HttpUrl.Builder()
-          .scheme(NominatimConstants.SCHEME)
-          .host(NominatimConstants.HOST)
-          .addPathSegment("search.php")
-          .addQueryParameter("q", java.net.URLEncoder.encode(name, "UTF-8"))
-          .addQueryParameter("format", "jsonv2")
-          .addQueryParameter("limit", limit.toString())
-          .build()
+    val request = Request.Builder().url(url).addHeader("User-Agent", "Chimpagne").build()
+    client.newCall(request).enqueue(object : Callback {
+        override fun onFailure(call: Call, e: IOException) {
+            Log.e("LocationHelper", "Failed to get location for $name, because of IO Exception", e)
+            onResult(listOf())
+        }
 
-  val request = Request.Builder().url(url).addHeader("User-Agent", "Chimpagne").build()
-  client
-      .newCall(request)
-      .enqueue(
-          object : Callback {
-
-            override fun onFailure(call: Call, e: IOException) {
-              Log.e(
-                  "LocationHelper", "Failed to get location for $name, because of IO Exception", e)
-              onResult(listOf())
-            }
-
-            override fun onResponse(call: Call, response: Response) {
-              response.use {
+        override fun onResponse(call: Call, response: Response) {
+            response.use {
                 if (!response.isSuccessful) {
-                  Log.e(
-                      "LocationHelper",
-                      "Failed to get location for $name, because of unsuccessful response")
-                  onResult(listOf())
-                } else {
-                  val geoLocation = response.body?.string()
-                  val jsonArray = geoLocation?.let { JSONArray(it) }
-                  if (jsonArray != null && jsonArray.length() > 0) {
-                    val locations = arrayListOf<Location>()
-                    for (i in 0 ..< jsonArray.length()) {
-                      val jsonObject = jsonArray.getJSONObject(i)
-                      val locName = jsonObject.getString("display_name")
-                      val lat = jsonObject.getDouble("lat")
-                      val lon = jsonObject.getDouble("lon")
-                      locations.add(Location(locName, lat, lon))
-                    }
-                    onResult(locations)
-                  } else {
-                    Log.e(
-                        "LocationHelper",
-                        "Failed to get location for $name, because of empty response")
+                    Log.e("LocationHelper", "Failed to get location for $name, because of unsuccessful response")
                     onResult(listOf())
-                  }
+                } else {
+                    val jsonString = response.body?.string()
+                    val jsonArray = jsonString?.let { JSONArray(it) }
+                    val uniqueDisplayNames = mutableSetOf<String>()
+                    val locations = mutableListOf<Location>()
+
+                    if (jsonArray != null) {
+                        for (i in 0 until jsonArray.length()) {
+                            val jsonObject = jsonArray.getJSONObject(i)
+                            val addressObject = jsonObject.getJSONObject("address")
+                            val category = jsonObject.optString("category", "")
+                            val country = addressObject.optString("country", "")
+                            val normalizedCountry = if (country == "Schweiz/Suisse/Svizzera/Svizra") "Switzerland" else country
+
+                            val displayName = when {
+                                category == "building" -> {
+                                    val road = addressObject.optString("road", "")
+                                    val houseNumber = addressObject.optString("house_number", "")
+                                    val postcode = addressObject.optString("postcode", "")
+                                    val village = addressObject.optString("village", addressObject.optString("town", addressObject.optString("city", "")))
+                                    "$road $houseNumber, $postcode, $village, $normalizedCountry"
+                                }
+                                category == "amenity" -> {
+                                    val amenity = addressObject.optString("amenity", "")
+                                    val locality = addressObject.optString("city", addressObject.optString("town", addressObject.optString("village", "")))
+                                    val postcode = addressObject.optString("postcode", "")
+                                    "$amenity, $locality, $postcode, $normalizedCountry"
+                                }
+                                else -> {
+                                    val specificCategoryValue = addressObject.optString(category, "")
+                                    val locality = addressObject.optString("city", addressObject.optString("town", addressObject.optString("village", "")))
+                                    val postcode = addressObject.optString("postcode", "")
+                                    if (specificCategoryValue.isNotEmpty()) "$specificCategoryValue, $category, $locality, $postcode, $normalizedCountry"
+                                    else "$locality, $postcode, $normalizedCountry"
+                                }
+                            }
+
+                            // Deduplication based on display name
+                            if (uniqueDisplayNames.add(displayName)) {
+                                val lat = jsonObject.getDouble("lat")
+                                val lon = jsonObject.getDouble("lon")
+                                locations.add(Location(displayName, lat, lon))
+                            }
+                        }
+                    }
+
+                    if (locations.isNotEmpty()) {
+                        onResult(locations)
+                    } else {
+                        Log.e("LocationHelper", "No unique locations found for $name")
+                        onResult(listOf())
+                    }
                 }
-              }
             }
-          })
+        }
+    })
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/LocationSelector.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/LocationSelector.kt
@@ -1,15 +1,23 @@
 package com.monkeyteam.chimpagne.ui.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -17,7 +25,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.location.Location
 import com.monkeyteam.chimpagne.model.location.convertNameToLocations
@@ -32,46 +42,77 @@ fun LocationSelector(
 
   var locationQuery by remember { mutableStateOf(selectedLocation?.name ?: "") }
   var searching by remember { mutableStateOf(false) }
-  var showSearchBar by remember { mutableStateOf(false) }
+    var showSearchBar by remember { mutableStateOf(false) }
+  var searchCompleted by remember { mutableStateOf(false) }
   var possibleLocations by remember { mutableStateOf(emptyList<Location>()) }
 
   val launchSearch = {
     searching = true
-    showSearchBar = false
+      showSearchBar = true
     convertNameToLocations(
         locationQuery,
         {
           possibleLocations = it
           searching = false
-          if (it.isNotEmpty()) showSearchBar = true
+          searchCompleted = it.isNotEmpty()
         },
         10)
   }
 
-  DockedSearchBar(
+    val clearLocationInput = {
+        locationQuery = ""
+        possibleLocations = emptyList()
+        searchCompleted = false
+        updateSelectedLocation(Location())
+    }
+
+
+    DockedSearchBar(
       query = locationQuery,
-      onQueryChange = { if (!searching) locationQuery = it },
+      onQueryChange = {
+          locationQuery = it
+          searchCompleted= false
+      },
       onSearch = { launchSearch() },
       active = showSearchBar,
-      onActiveChange = {},
+      onActiveChange = { showSearchBar = it},
       placeholder = { Text(stringResource(id = R.string.search_location)) },
       modifier = modifier,
-      trailingIcon = {
-        IconButton(onClick = launchSearch) {
-          if (!searching) Icon(imageVector = Icons.Default.Search, contentDescription = "Search")
-          else CircularProgressIndicator()
+        trailingIcon = {
+            when {
+                searching -> CircularProgressIndicator()
+                locationQuery.isNotEmpty() && searchCompleted -> IconButton(onClick = clearLocationInput) {
+                    Icon(imageVector = Icons.Default.Clear, contentDescription = "Clear")
+                }
+                locationQuery.isNotEmpty() && !searchCompleted -> IconButton(onClick = launchSearch) {
+                    Icon(imageVector = Icons.Default.Search, contentDescription = "Search")
+                }
+            }
+        }) {
+        if(possibleLocations.isNotEmpty()) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(8.dp), // Set a rounded corner shape
+                color = MaterialTheme.colorScheme.surface
+            ) {
+                LazyColumn {
+                    items(possibleLocations) { location ->
+                        Text(
+                            text = location.name,
+                            modifier = Modifier
+                                .clickable {
+                                    locationQuery = location.name
+                                    searchCompleted = true
+                                    showSearchBar = false
+                                    updateSelectedLocation(location)
+                                }
+                                .fillMaxWidth()
+                                .padding(16.dp)
+                        )
+                        HorizontalDivider(color = Color.LightGray)
+                    }
+                }
+            }
         }
-      }) {
-        LazyColumn {
-          items(possibleLocations) { location ->
-            Text(
-                location.name,
-                Modifier.clickable {
-                  locationQuery = location.name
-                  showSearchBar = false
-                  updateSelectedLocation(location)
-                })
-          }
-        }
-      }
+    }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/LocationSelector.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/LocationSelector.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
@@ -77,7 +78,7 @@ fun LocationSelector(
       active = showSearchBar,
       onActiveChange = { showSearchBar = it},
       placeholder = { Text(stringResource(id = R.string.search_location)) },
-      modifier = modifier,
+      modifier = modifier.testTag("LocationComponent"),
         trailingIcon = {
             when {
                 searching -> CircularProgressIndicator()

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user"/>
+            <certificates src="system"/>
+        </trust-anchors>
+    </debug-overrides>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system"/>
+        </trust-anchors>
+    </base-config>
+    <domain-config>
+        <domain includeSubdomains="true">localhost</domain>
+        <trust-anchors>
+            <certificates src="user"/>
+        </trust-anchors>
+    </domain-config>
+</network-security-config>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.3.2"
+androidxJunit = "4.12"
 coilCompose = "2.6.0"
 coilComposeVersion = "2.6.0"
 firebaseBom = "32.8.0"
@@ -9,6 +10,7 @@ geofireAndroidCommon = "3.2.0"
 kotlin = "1.9.0"
 coreKtx = "1.12.0"
 junit = "4.13.2"
+kotlinxCoroutinesTest = "1.7.2"
 material3 = "1.2.1"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
@@ -17,8 +19,11 @@ activityCompose = "1.8.2"
 composeBom = "2024.04.00"
 mapsCompose = "4.3.3"
 materialIconsExtended = "1.6.5"
+mockitoAndroid = "2.12.0"
+mockitoCore = "3.11.2"
+mockitoInline = "3.3.3"
+mockwebserverVersion = "4.9.0"
 navigationCompose = "2.7.7"
-mockwebserver = "4.12.0"
 secretsGradlePlugin = "2.0.1"
 googleServices = "4.4.1"
 ktfmt = "0.17.0"
@@ -26,6 +31,7 @@ sonar = "4.4.1.3373"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-junit-v412 = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
@@ -46,8 +52,12 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
+mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroid" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserverVersion" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version = "4.12.0" }
 secrets-gradle-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "secretsGradlePlugin" }
 


### PR DESCRIPTION
I've refined the geolocation features within `Nominatim.kt` and `LocationSelector.kt` to enhance user interaction and data presentation. The LazyColumn now neatly displays up to five search results, each distinctly bounded for improved clarity. Addressing the JSON response variability was a significant challenge, as the returned data's format could vary widely based on the user's query. There was no straightforward, all-encompassing method to selectively display only the relevant attributes since they might or might not be present in the response from the Nominatim API. However, I devised tailored solutions for different scenarios, leading to a codebase that's not only more readable but also more maintainable. Additionally, I've implemented a feature for easy clearing of the location input, which streamlines the user experience by eliminating the previous, annoying manual process. I am currently working on testing these new features. 

I have 74% of line coverage.