### PR TITLE
ktfmt is back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,6 @@ jobs:
         run: |
           chmod +x ./gradlew
 
-      - name: Format code with KTFmt
-        run: |
-          ./gradlew ktfmtFormat
-
       # Check formatting
       - name: Check code formatted with KTFmt
         run: |


### PR DESCRIPTION
I've removed the ktfmt hack in ci.yml to make the CI pass even if your code isn't well formatted. You cannot hide from him !
![eSJAt-2341923830](https://github.com/Chimpagne/ChimpagneApp/assets/39198541/b343f7ab-22c5-4fad-bbd4-3decb158ad6f)
