### PR TITLE
Get role

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/TestUtils.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/TestUtils.kt
@@ -26,7 +26,8 @@ val TEST_EVENTS =
             guests = emptyMap(),
             staffs = emptyMap(),
             startsAtTimestamp = buildTimestamp(9, 5, 2024, 0, 0),
-            endsAtTimestamp = buildTimestamp(10, 5, 2024, 0, 0)),
+            endsAtTimestamp = buildTimestamp(10, 5, 2024, 0, 0),
+            ownerId = "PRINCE"),
         ChimpagneEvent(
             id = "SECOND_EVENT",
             title = "Second event",

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/EventTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/EventTest.kt
@@ -1,0 +1,20 @@
+package com.monkeyteam.chimpagne.newtests.model.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EventTest {
+
+  @Test
+  fun guestListAndStaffListTest() {
+    val event =
+        ChimpagneEvent(
+            staffs = hashMapOf("1" to true, "2" to true), guests = hashMapOf("3" to true))
+    assertEquals(event.guests.keys, event.guestList())
+    assertEquals(event.staffs.keys, event.staffList())
+  }
+}

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/JoinEventTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/JoinEventTests.kt
@@ -1,0 +1,81 @@
+package com.monkeyteam.chimpagne.newtests.model.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
+import com.monkeyteam.chimpagne.model.database.ChimpagneRole
+import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
+import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotSame
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class JoinEventTests {
+
+  val database = Database()
+  val accountManager = database.accountManager
+  val eventManager = database.eventManager
+
+  val loggedAccount = TEST_ACCOUNTS[0]
+  val anotherAccount = TEST_ACCOUNTS[2]
+
+  @Before
+  fun init() {
+    initializeTestDatabase()
+    accountManager.signInTo(loggedAccount)
+  }
+
+  @Test
+  fun test() {
+    var eventId = ""
+    eventManager.createEvent(
+      ChimpagneEvent(
+        title = "Banana Land"
+      ), { eventId = it }, { assertTrue(false) }
+    )
+    while (eventId == "") {
+    }
+    var e: ChimpagneEvent? = null;
+    eventManager.getEventById(eventId, {e = it}, { assertTrue(false) })
+    while (e == null) {
+    }
+    var event = e!!
+
+    assertEquals(loggedAccount.firebaseAuthUID, event.ownerId)
+    assertEquals(ChimpagneRole.OWNER, event.getRole(loggedAccount.firebaseAuthUID))
+    assertEquals(ChimpagneRole.NOT_IN_EVENT, event.getRole(anotherAccount.firebaseAuthUID))
+
+    var loading = true
+    eventManager.addGuest(eventId, anotherAccount.firebaseAuthUID, {loading = false}, { loading = false; assertTrue(false) })
+    while (loading) {}
+    e = null;
+    eventManager.getEventById(eventId, {e = it}, { assertTrue(false) })
+    while (e == null) {
+    }
+    event = e!!
+
+    assertEquals(loggedAccount.firebaseAuthUID, event.ownerId)
+    assertEquals(ChimpagneRole.OWNER, event.getRole(loggedAccount.firebaseAuthUID))
+    assertEquals(ChimpagneRole.GUEST, event.getRole(anotherAccount.firebaseAuthUID))
+
+    accountManager.signInTo(anotherAccount)
+    loading = true
+    accountManager.joinEvent(eventId, ChimpagneRole.STAFF, {loading = false}, { assertTrue(false) })
+    while (loading) {}
+    e = null;
+    eventManager.getEventById(eventId, {e = it}, { assertTrue(false) })
+    while (e == null) {
+    }
+    event = e!!
+
+    assertEquals(loggedAccount.firebaseAuthUID, event.ownerId)
+    assertEquals(ChimpagneRole.OWNER, event.getRole(loggedAccount.firebaseAuthUID))
+    assertTrue(ChimpagneRole.GUEST != event.getRole(anotherAccount.firebaseAuthUID))
+    assertEquals(ChimpagneRole.STAFF, event.getRole(anotherAccount.firebaseAuthUID))
+  }
+
+}

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/JoinEventTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/JoinEventTests.kt
@@ -7,7 +7,6 @@ import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
 import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNotSame
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -33,16 +32,11 @@ class JoinEventTests {
   fun test() {
     var eventId = ""
     eventManager.createEvent(
-      ChimpagneEvent(
-        title = "Banana Land"
-      ), { eventId = it }, { assertTrue(false) }
-    )
-    while (eventId == "") {
-    }
-    var e: ChimpagneEvent? = null;
-    eventManager.getEventById(eventId, {e = it}, { assertTrue(false) })
-    while (e == null) {
-    }
+        ChimpagneEvent(title = "Banana Land"), { eventId = it }, { assertTrue(false) })
+    while (eventId == "") {}
+    var e: ChimpagneEvent? = null
+    eventManager.getEventById(eventId, { e = it }, { assertTrue(false) })
+    while (e == null) {}
     var event = e!!
 
     assertEquals(loggedAccount.firebaseAuthUID, event.ownerId)
@@ -50,12 +44,18 @@ class JoinEventTests {
     assertEquals(ChimpagneRole.NOT_IN_EVENT, event.getRole(anotherAccount.firebaseAuthUID))
 
     var loading = true
-    eventManager.addGuest(eventId, anotherAccount.firebaseAuthUID, {loading = false}, { loading = false; assertTrue(false) })
+    eventManager.addGuest(
+        eventId,
+        anotherAccount.firebaseAuthUID,
+        { loading = false },
+        {
+          loading = false
+          assertTrue(false)
+        })
     while (loading) {}
-    e = null;
-    eventManager.getEventById(eventId, {e = it}, { assertTrue(false) })
-    while (e == null) {
-    }
+    e = null
+    eventManager.getEventById(eventId, { e = it }, { assertTrue(false) })
+    while (e == null) {}
     event = e!!
 
     assertEquals(loggedAccount.firebaseAuthUID, event.ownerId)
@@ -64,12 +64,12 @@ class JoinEventTests {
 
     accountManager.signInTo(anotherAccount)
     loading = true
-    accountManager.joinEvent(eventId, ChimpagneRole.STAFF, {loading = false}, { assertTrue(false) })
+    accountManager.joinEvent(
+        eventId, ChimpagneRole.STAFF, { loading = false }, { assertTrue(false) })
     while (loading) {}
-    e = null;
-    eventManager.getEventById(eventId, {e = it}, { assertTrue(false) })
-    while (e == null) {
-    }
+    e = null
+    eventManager.getEventById(eventId, { e = it }, { assertTrue(false) })
+    while (e == null) {}
     event = e!!
 
     assertEquals(loggedAccount.firebaseAuthUID, event.ownerId)
@@ -77,5 +77,4 @@ class JoinEventTests {
     assertTrue(ChimpagneRole.GUEST != event.getRole(anotherAccount.firebaseAuthUID))
     assertEquals(ChimpagneRole.STAFF, event.getRole(anotherAccount.firebaseAuthUID))
   }
-
 }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/JoinEventTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/JoinEventTests.kt
@@ -35,7 +35,9 @@ class JoinEventTests {
 
     var eventId = ""
     eventManager.createEvent(
-        ChimpagneEvent(title = "Banana Land"), { eventId = it }, { assertTrue(false) })
+        ChimpagneEvent(title = "Banana Land", ownerId = anAccount.firebaseAuthUID),
+        { eventId = it },
+        { assertTrue(false) })
     while (eventId == "") {}
     var e: ChimpagneEvent? = null
     eventManager.getEventById(eventId, { e = it }, { assertTrue(false) })

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/MyEventsScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/MyEventsScreenTests.kt
@@ -31,6 +31,7 @@ class MyEventsScreenTests {
   @Before
   fun initTests() {
     initializeTestDatabase()
+    database.accountManager.signInTo(TEST_ACCOUNTS[0])
   }
 
   @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ViewDetailEventScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ViewDetailEventScreenTests.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
 import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
 import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
 import com.monkeyteam.chimpagne.ui.ViewDetailEventScreen
@@ -90,8 +91,8 @@ class ViewDetailEventScreenTests {
 
   @Test
   fun testEditButton() {
+    database.accountManager.signInTo(TEST_ACCOUNTS[0])
     val event = TEST_EVENTS[0]
-
     val eventVM = EventViewModel(event.id, database)
 
     while (eventVM.uiState.value.loading) {}

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ViewDetailEventScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ViewDetailEventScreenTests.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
 import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
@@ -100,7 +99,7 @@ class ViewDetailEventScreenTests {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navActions = NavigationActions(navController)
-      ViewDetailEventScreen(navActions, eventVM, ChimpagneRole.OWNER)
+      ViewDetailEventScreen(navActions, eventVM)
     }
 
     composeTestRule.onNodeWithTag("edit").assertHasClickAction()

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ViewDetailEventScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ViewDetailEventScreenTests.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
 import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
@@ -99,7 +100,7 @@ class ViewDetailEventScreenTests {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navActions = NavigationActions(navController)
-      ViewDetailEventScreen(navActions, eventVM, true)
+      ViewDetailEventScreen(navActions, eventVM, ChimpagneRole.OWNER)
     }
 
     composeTestRule.onNodeWithTag("edit").assertHasClickAction()

--- a/app/src/main/java/com/monkeyteam/chimpagne/MainActivity.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.firebase.ui.auth.AuthUI
 import com.google.firebase.auth.FirebaseAuth
+import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.model.database.PUBLIC_TABLES
 import com.monkeyteam.chimpagne.ui.AccountEdit
@@ -113,7 +114,7 @@ class MainActivity : ComponentActivity() {
                   navObject = navActions,
                   myEventsViewModel = viewModel(factory = MyEventsViewModelFactory(database)))
             }
-            composable(Route.VIEW_DETAIL_EVENT_SCREEN + "/{EventID}/{CanEdit}") { backStackEntry ->
+            composable(Route.VIEW_DETAIL_EVENT_SCREEN + "/{EventID}/{Role}") { backStackEntry ->
               ViewDetailEventScreen(
                   navObject = navActions,
                   eventViewModel =
@@ -121,7 +122,7 @@ class MainActivity : ComponentActivity() {
                           factory =
                               EventViewModelFactory(
                                   backStackEntry.arguments?.getString("EventID"), database)),
-                  canEditEvent = backStackEntry.arguments?.getString("CanEdit").toBoolean())
+                  userRole = ChimpagneRole.valueOf(backStackEntry.arguments?.getString("Role")!!))
             }
           }
         }

--- a/app/src/main/java/com/monkeyteam/chimpagne/MainActivity.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/MainActivity.kt
@@ -17,7 +17,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.firebase.ui.auth.AuthUI
 import com.google.firebase.auth.FirebaseAuth
-import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.model.database.PUBLIC_TABLES
 import com.monkeyteam.chimpagne.ui.AccountEdit
@@ -114,15 +113,14 @@ class MainActivity : ComponentActivity() {
                   navObject = navActions,
                   myEventsViewModel = viewModel(factory = MyEventsViewModelFactory(database)))
             }
-            composable(Route.VIEW_DETAIL_EVENT_SCREEN + "/{EventID}/{Role}") { backStackEntry ->
+            composable(Route.VIEW_DETAIL_EVENT_SCREEN + "/{EventID}") { backStackEntry ->
               ViewDetailEventScreen(
                   navObject = navActions,
                   eventViewModel =
                       viewModel(
                           factory =
                               EventViewModelFactory(
-                                  backStackEntry.arguments?.getString("EventID"), database)),
-                  userRole = ChimpagneRole.valueOf(backStackEntry.arguments?.getString("Role")!!))
+                                  backStackEntry.arguments?.getString("EventID"), database)))
             }
           }
         }

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
@@ -170,7 +170,9 @@ class ChimpagneAccountManager(
               { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
               onFailure)
       ChimpagneRole.OWNER -> updateCurrentAccount(updatedAccount, onSuccess, onFailure)
-      ChimpagneRole.NOT_IN_EVENT -> onFailure(Exception("Joining an event with ChimpagneRole.NOT_IN_EVENT ! Are you stupid ?"))
+      ChimpagneRole.NOT_IN_EVENT ->
+          onFailure(
+              Exception("Joining an event with ChimpagneRole.NOT_IN_EVENT ! Are you stupid ?"))
     }
   }
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
@@ -145,7 +145,7 @@ class ChimpagneAccountManager(
   /** @param role: ChimpagneRole (for instance ChimpagneRoles.GUEST) */
   fun joinEvent(
       id: ChimpagneEventId,
-      role: Int,
+      role: ChimpagneRole,
       onSuccess: () -> Unit = {},
       onFailure: (Exception) -> Unit = {}
   ) {
@@ -157,19 +157,20 @@ class ChimpagneAccountManager(
     val updatedAccount =
         currentUserAccount!!.copy(joinedEvents = currentUserAccount!!.joinedEvents + (id to true))
     when (role) {
-      ChimpagneRoles.GUEST ->
+      ChimpagneRole.GUEST ->
           eventManager.addGuest(
               id,
               updatedAccount.firebaseAuthUID,
               { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
               onFailure)
-      ChimpagneRoles.STAFF ->
+      ChimpagneRole.STAFF ->
           eventManager.addStaff(
               id,
               updatedAccount.firebaseAuthUID,
               { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
               onFailure)
-      else -> updateCurrentAccount(updatedAccount, onSuccess, onFailure)
+      ChimpagneRole.OWNER -> updateCurrentAccount(updatedAccount, onSuccess, onFailure)
+      ChimpagneRole.NOT_IN_EVENT -> onFailure(Exception("Joining an event with ChimpagneRole.NOT_IN_EVENT ! Are you stupid ?"))
     }
   }
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEvent.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEvent.kt
@@ -42,7 +42,7 @@ data class ChimpagneEvent(
     return buildCalendar(endsAtTimestamp)
   }
 
-  fun getRole(userUID: ChimpagneAccountUID) : ChimpagneRole {
+  fun getRole(userUID: ChimpagneAccountUID): ChimpagneRole {
     if (ownerId == userUID) return ChimpagneRole.OWNER
     if (staffs[userUID] == true) return ChimpagneRole.STAFF
     if (guests[userUID] == true) return ChimpagneRole.GUEST

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEvent.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEvent.kt
@@ -42,6 +42,13 @@ data class ChimpagneEvent(
     return buildCalendar(endsAtTimestamp)
   }
 
+  fun getRole(userUID: ChimpagneAccountUID) : ChimpagneRole {
+    if (ownerId == userUID) return ChimpagneRole.OWNER
+    if (staffs[userUID] == true) return ChimpagneRole.STAFF
+    if (guests[userUID] == true) return ChimpagneRole.GUEST
+    return ChimpagneRole.NOT_IN_EVENT
+  }
+
   constructor(
       id: String,
       title: String,

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
@@ -95,7 +95,7 @@ class ChimpagneEventManager(
             id = eventId, ownerId = database.accountManager.currentUserAccount?.firebaseAuthUID!!),
         {
           database.accountManager.joinEvent(
-              eventId, ChimpagneRoles.OWNER, { onSuccess(eventId) }, { onFailure(it) })
+              eventId, ChimpagneRole.OWNER, { onSuccess(eventId) }, { onFailure(it) })
         },
         { onFailure(it) })
   }

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneRole.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneRole.kt
@@ -1,0 +1,5 @@
+package com.monkeyteam.chimpagne.model.database
+
+enum class ChimpagneRole {
+  OWNER, STAFF, GUEST, NOT_IN_EVENT
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneRole.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneRole.kt
@@ -1,5 +1,8 @@
 package com.monkeyteam.chimpagne.model.database
 
 enum class ChimpagneRole {
-  OWNER, STAFF, GUEST, NOT_IN_EVENT
+  OWNER,
+  STAFF,
+  GUEST,
+  NOT_IN_EVENT
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneRoles.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneRoles.kt
@@ -1,9 +1,0 @@
-package com.monkeyteam.chimpagne.model.database
-
-typealias ChimpagneRole = Int
-
-object ChimpagneRoles {
-  val OWNER: ChimpagneRole = 0
-  val STAFF: ChimpagneRole = 1
-  val GUEST: ChimpagneRole = 2
-}

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
+import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.utils.timestampToStringWithDateAndTime
 import com.monkeyteam.chimpagne.ui.components.Legend
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
@@ -94,7 +96,7 @@ fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsView
                         location = event.location.name,
                         modifier = Modifier.testTag("a created event")) {
                           navObject.navigateTo(
-                              Route.VIEW_DETAIL_EVENT_SCREEN + "/${event.id}" + "/true")
+                            Route.VIEW_DETAIL_EVENT_SCREEN + "/${event.id}" + "/" + event.getRole(uiState.userUID))
                         }
                   }
                 }
@@ -119,7 +121,7 @@ fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsView
                         location = event.location.name,
                         modifier = Modifier.testTag("a joined event")) {
                           navObject.navigateTo(
-                              Route.VIEW_DETAIL_EVENT_SCREEN + "/${event.id}" + "/false")
+                              Route.VIEW_DETAIL_EVENT_SCREEN + "/${event.id}" + "/" + event.getRole(uiState.userUID))
                         }
                   }
                 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
@@ -93,11 +93,7 @@ fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsView
                         date = timestampToStringWithDateAndTime(event.startsAtTimestamp),
                         location = event.location.name,
                         modifier = Modifier.testTag("a created event")) {
-                          navObject.navigateTo(
-                              Route.VIEW_DETAIL_EVENT_SCREEN +
-                                  "/${event.id}" +
-                                  "/" +
-                                  event.getRole(uiState.userUID))
+                          navObject.navigateTo(Route.VIEW_DETAIL_EVENT_SCREEN + "/${event.id}")
                         }
                   }
                 }
@@ -121,11 +117,7 @@ fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsView
                         date = timestampToStringWithDateAndTime(event.startsAtTimestamp),
                         location = event.location.name,
                         modifier = Modifier.testTag("a joined event")) {
-                          navObject.navigateTo(
-                              Route.VIEW_DETAIL_EVENT_SCREEN +
-                                  "/${event.id}" +
-                                  "/" +
-                                  event.getRole(uiState.userUID))
+                          navObject.navigateTo(Route.VIEW_DETAIL_EVENT_SCREEN + "/${event.id}")
                         }
                   }
                 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
@@ -38,8 +38,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.monkeyteam.chimpagne.R
-import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
-import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.utils.timestampToStringWithDateAndTime
 import com.monkeyteam.chimpagne.ui.components.Legend
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
@@ -96,7 +94,10 @@ fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsView
                         location = event.location.name,
                         modifier = Modifier.testTag("a created event")) {
                           navObject.navigateTo(
-                            Route.VIEW_DETAIL_EVENT_SCREEN + "/${event.id}" + "/" + event.getRole(uiState.userUID))
+                              Route.VIEW_DETAIL_EVENT_SCREEN +
+                                  "/${event.id}" +
+                                  "/" +
+                                  event.getRole(uiState.userUID))
                         }
                   }
                 }
@@ -121,7 +122,10 @@ fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsView
                         location = event.location.name,
                         modifier = Modifier.testTag("a joined event")) {
                           navObject.navigateTo(
-                              Route.VIEW_DETAIL_EVENT_SCREEN + "/${event.id}" + "/" + event.getRole(uiState.userUID))
+                              Route.VIEW_DETAIL_EVENT_SCREEN +
+                                  "/${event.id}" +
+                                  "/" +
+                                  event.getRole(uiState.userUID))
                         }
                   }
                 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.utils.buildTimestamp
 import com.monkeyteam.chimpagne.model.utils.timestampToStringWithDateAndTime
 import com.monkeyteam.chimpagne.ui.components.ChimpagneButton
@@ -59,7 +60,7 @@ import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 fun ViewDetailEventScreen(
     navObject: NavigationActions,
     eventViewModel: EventViewModel,
-    canEditEvent: Boolean = false
+    userRole: ChimpagneRole = ChimpagneRole.GUEST
 ) {
   val uiState by eventViewModel.uiState.collectAsState()
   val context = LocalContext.current
@@ -133,7 +134,7 @@ fun ViewDetailEventScreen(
                                     .absolutePadding(left = 16.dp, right = 16.dp)
                                     .testTag("description"))
                         Spacer(Modifier.height(16.dp))
-                        if (!canEditEvent) {
+                        if (userRole != ChimpagneRole.OWNER) {
                           ChimpagneButton(
                               text =
                                   stringResource(id = R.string.event_details_screen_leave_button),
@@ -160,7 +161,7 @@ fun ViewDetailEventScreen(
                                     })
                               })
                         }
-                        if (canEditEvent) {
+                        if (userRole == ChimpagneRole.OWNER) { // Only the owner can edit the event settings
                           ChimpagneButton(
                               text = stringResource(id = R.string.event_details_screen_edit_button),
                               icon = Icons.Rounded.Edit,

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
@@ -161,7 +161,8 @@ fun ViewDetailEventScreen(
                                     })
                               })
                         }
-                        if (userRole == ChimpagneRole.OWNER) { // Only the owner can edit the event settings
+                        if (userRole ==
+                            ChimpagneRole.OWNER) { // Only the owner can edit the event settings
                           ChimpagneButton(
                               text = stringResource(id = R.string.event_details_screen_edit_button),
                               icon = Icons.Rounded.Edit,

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
@@ -57,13 +57,11 @@ import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ViewDetailEventScreen(
-    navObject: NavigationActions,
-    eventViewModel: EventViewModel,
-    userRole: ChimpagneRole = ChimpagneRole.GUEST
-) {
+fun ViewDetailEventScreen(navObject: NavigationActions, eventViewModel: EventViewModel) {
   val uiState by eventViewModel.uiState.collectAsState()
   val context = LocalContext.current
+
+  val userRole = eventViewModel.getCurrentUserRole()
 
   Scaffold(
       topBar = {

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -254,6 +254,14 @@ class EventViewModel(
   fun removeSupply(supplyId: ChimpagneSupplyId) {
     _uiState.value = _uiState.value.copy(supplies = _uiState.value.supplies - supplyId)
   }
+
+  fun getRole(userUID: ChimpagneAccountUID): ChimpagneRole {
+    return buildChimpagneEvent().getRole(userUID)
+  }
+
+  fun getCurrentUserRole(): ChimpagneRole {
+    return getRole(accountManager.currentUserAccount?.firebaseAuthUID ?: "")
+  }
 }
 
 data class EventUIState(

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/FindEventsViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/FindEventsViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.firestore.Filter
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.database.ChimpagneEventId
-import com.monkeyteam.chimpagne.model.database.ChimpagneRoles
+import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.model.database.containsTagsFilter
 import com.monkeyteam.chimpagne.model.database.happensOnThisDateFilter
@@ -90,7 +90,7 @@ class FindEventsViewModel(database: Database) : ViewModel() {
   }
 
   fun joinEvent(eventId: ChimpagneEventId, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    accountManager.joinEvent(eventId, ChimpagneRoles.GUEST, onSuccess, onFailure)
+    accountManager.joinEvent(eventId, ChimpagneRole.GUEST, onSuccess, onFailure)
   }
 }
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/MyEventsViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/MyEventsViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.database.Database
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,7 +27,7 @@ class MyEventsViewModel(
   }
 
   private fun fetchMyEvents(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
-    _uiState.value = _uiState.value.copy(loading = true)
+    _uiState.value = _uiState.value.copy(loading = true, userUID = accountManager.currentUserAccount?.firebaseAuthUID!!)
     viewModelScope.launch {
       accountManager.getAllOfMyEvents(
           { createdEvents, joinedEvents ->
@@ -49,6 +50,7 @@ class MyEventsViewModel(
 data class MyEventsUIState(
     val createdEvents: Map<String, ChimpagneEvent> = emptyMap(),
     val joinedEvents: Map<String, ChimpagneEvent> = emptyMap(),
+    val userUID: ChimpagneAccountUID = "",
     val loading: Boolean = false
 )
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/MyEventsViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/MyEventsViewModel.kt
@@ -27,7 +27,9 @@ class MyEventsViewModel(
   }
 
   private fun fetchMyEvents(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
-    _uiState.value = _uiState.value.copy(loading = true, userUID = accountManager.currentUserAccount?.firebaseAuthUID!!)
+    _uiState.value =
+        _uiState.value.copy(
+            loading = true, userUID = accountManager.currentUserAccount?.firebaseAuthUID!!)
     viewModelScope.launch {
       accountManager.getAllOfMyEvents(
           { createdEvents, joinedEvents ->


### PR DESCRIPTION
This PR greatly simplifies the role management of the app.

As asked in #105, I replaced the ugly object ChimpagneRoles by a clean enum ChimpagneRole:
- ChimpagneRole.OWNER -> the user if the King Kong of the event
- ChimpagneRole.STAFF -> the user is in the event stafflist
- ChimpagneRole.GUEST -> the user is in the event guestlist
- CimpagneRole.NOT_IN_EVENT -> the user isn't in the event

On a ChimpagneEvent, you can now call the method getRole(ChimpagneAccountUID) to get the role of user, no need to check yourself the stafflist, guestlist and ownerId fields.

I also modified  ViewDetailedEventScreen to take a ChimpagneRole (instead of a boolean saying if the user can edit or not the event) to easily make the difference between the owner and a staff. 