### PR TITLE
Double CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI - Test Runner
 on:
   push:
     branches:
-      - '**'
+      - 'main'
 
   pull_request:
     types:


### PR DESCRIPTION
As you might have noticed, on a pull request, the CI is launched 2 times. This not only slows down tests but also can break them because of database concurrency issues. This simple PR solves this issue by launching the CI only one time.

This
![image](https://github.com/Chimpagne/ChimpagneApp/assets/39198541/fbd09211-243a-481f-afdd-f24a10139b1f)
becomes
![image](https://github.com/Chimpagne/ChimpagneApp/assets/39198541/3ef35417-f6d6-4680-af46-08118a9ae90b)
