### PR TITLE
EventViewModel: auto add ownerId on buildChimpagneEvent()

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/EventCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/EventCreationScreenTest.kt
@@ -16,11 +16,14 @@ import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
+import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
 import com.monkeyteam.chimpagne.ui.EventCreationScreen
 import com.monkeyteam.chimpagne.ui.components.SupplyPopup
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.EventViewModelFactory
 import org.junit.Assert.*
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,6 +43,12 @@ class EventCreationScreenTest {
   val database = Database()
 
   @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun init() {
+    initializeTestDatabase()
+    database.accountManager.signInTo(TEST_ACCOUNTS[0])
+  }
 
   @Test
   fun testPanels() {

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
@@ -91,8 +91,7 @@ class ChimpagneEventManager(
 
     val eventId = events.document().id
     updateEvent(
-        event.copy(
-            id = eventId, ownerId = database.accountManager.currentUserAccount?.firebaseAuthUID!!),
+        event.copy(id = eventId),
         {
           database.accountManager.joinEvent(
               eventId, ChimpagneRoles.OWNER, { onSuccess(eventId) }, { onFailure(it) })

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -78,20 +78,20 @@ class EventViewModel(
 
   private fun buildChimpagneEvent(): ChimpagneEvent {
     return ChimpagneEvent(
-        _uiState.value.id,
-        _uiState.value.title,
-        _uiState.value.description,
-        _uiState.value.location,
-        _uiState.value.public,
-        _uiState.value.tags,
-        _uiState.value.guests,
-        _uiState.value.staffs,
-        _uiState.value.startsAtCalendarDate,
-        _uiState.value.endsAtCalendarDate,
-        "", // This will be handled in the database
-        _uiState.value.supplies,
-        _uiState.value.parkingSpaces,
-        _uiState.value.beds)
+        id = _uiState.value.id,
+        title = _uiState.value.title,
+        description = _uiState.value.description,
+        location = _uiState.value.location,
+        public = _uiState.value.public,
+        tags = _uiState.value.tags,
+        guests = _uiState.value.guests,
+        staffs = _uiState.value.staffs,
+        startsAt = _uiState.value.startsAtCalendarDate,
+        endsAt = _uiState.value.endsAtCalendarDate,
+        ownerId = accountManager.currentUserAccount?.firebaseAuthUID!!,
+        supplies = _uiState.value.supplies,
+        parkingSpaces = _uiState.value.parkingSpaces,
+        beds = _uiState.value.beds)
   }
 
   fun createTheEvent(onSuccess: (id: String) -> Unit = {}, onFailure: (Exception) -> Unit = {}) {

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
@@ -32,6 +33,9 @@ class EventViewModel(
   init {
     if (eventID != null) {
       fetchEvent(eventID, onSuccess, onFailure)
+    } else {
+      _uiState.value =
+          EventUIState(ownerId = accountManager.currentUserAccount?.firebaseAuthUID ?: "")
     }
   }
 
@@ -60,7 +64,8 @@ class EventViewModel(
                       it.endsAt(),
                       it.supplies,
                       it.parkingSpaces,
-                      it.beds)
+                      it.beds,
+                      it.ownerId)
               onSuccess()
               _uiState.value = _uiState.value.copy(loading = false)
             } else {
@@ -88,7 +93,7 @@ class EventViewModel(
         staffs = _uiState.value.staffs,
         startsAt = _uiState.value.startsAtCalendarDate,
         endsAt = _uiState.value.endsAtCalendarDate,
-        ownerId = accountManager.currentUserAccount?.firebaseAuthUID!!,
+        ownerId = _uiState.value.ownerId,
         supplies = _uiState.value.supplies,
         parkingSpaces = _uiState.value.parkingSpaces,
         beds = _uiState.value.beds)
@@ -265,6 +270,9 @@ data class EventUIState(
     val supplies: Map<ChimpagneSupplyId, ChimpagneSupply> = mapOf(),
     val parkingSpaces: Int = 0,
     val beds: Int = 0,
+
+    // unmodifiable the UI
+    val ownerId: ChimpagneAccountUID = "",
     val loading: Boolean = false,
 )
 


### PR DESCRIPTION
This PR aims to solve an issue in the way we create and edit events with ChimpagneEventManager and EventViewModel. 
Before, the method buildChimpagneEvent of EventViewModel assumed the ownerId of the event would be added by the Database. While it worked well, it made impossible to get the ownerId of the event from the UI layer.

I solved this issue by adding a ownerId field to EventUIState. At the creation of the ViewModel, if eventID is null (i.e. you are creating the event), this field is set to the UID of the current logged account.