### PR TITLE
Fixed issue #119

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ViewDetailEventScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ViewDetailEventScreenTests.kt
@@ -73,6 +73,7 @@ class ViewDetailEventScreenTests {
 
   @Test
   fun testLeaveButton() {
+    database.accountManager.signInTo(TEST_ACCOUNTS[1])
     val event = TEST_EVENTS[0]
 
     val eventVM = EventViewModel(event.id, database)

--- a/app/src/main/java/com/monkeyteam/chimpagne/MainActivity.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/MainActivity.kt
@@ -33,8 +33,10 @@ import com.monkeyteam.chimpagne.ui.theme.ChimpagneTheme
 import com.monkeyteam.chimpagne.ui.utilities.SpinnerView
 import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
 import com.monkeyteam.chimpagne.viewmodels.AccountViewModelFactory
+import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 import com.monkeyteam.chimpagne.viewmodels.EventViewModelFactory
 import com.monkeyteam.chimpagne.viewmodels.FindEventsViewModelFactory
+import com.monkeyteam.chimpagne.viewmodels.MyEventsViewModel
 import com.monkeyteam.chimpagne.viewmodels.MyEventsViewModelFactory
 
 class MainActivity : ComponentActivity() {
@@ -109,18 +111,19 @@ class MainActivity : ComponentActivity() {
                   eventViewModel = viewModel(factory = EventViewModelFactory(null, database)))
             }
             composable(Route.MY_EVENTS_SCREEN) {
-              MyEventsScreen(
-                  navObject = navActions,
-                  myEventsViewModel = viewModel(factory = MyEventsViewModelFactory(database)))
+              val myEventsViewModel: MyEventsViewModel =
+                  viewModel(factory = MyEventsViewModelFactory(database))
+              myEventsViewModel.fetchMyEvents()
+              MyEventsScreen(navObject = navActions, myEventsViewModel = myEventsViewModel)
             }
             composable(Route.VIEW_DETAIL_EVENT_SCREEN + "/{EventID}") { backStackEntry ->
-              ViewDetailEventScreen(
-                  navObject = navActions,
-                  eventViewModel =
-                      viewModel(
-                          factory =
-                              EventViewModelFactory(
-                                  backStackEntry.arguments?.getString("EventID"), database)))
+              val eventViewModel: EventViewModel =
+                  viewModel(
+                      factory =
+                          EventViewModelFactory(
+                              backStackEntry.arguments?.getString("EventID"), database))
+              eventViewModel.fetchEvent()
+              ViewDetailEventScreen(navObject = navActions, eventViewModel = eventViewModel)
             }
           }
         }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
@@ -49,7 +49,6 @@ import com.monkeyteam.chimpagne.viewmodels.MyEventsViewModel
 @Composable
 fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsViewModel) {
   val uiState by myEventsViewModel.uiState.collectAsState()
-  myEventsViewModel.fetchMyEvents()
   Scaffold(
       topBar = {
         TopAppBar(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
@@ -49,6 +49,7 @@ import com.monkeyteam.chimpagne.viewmodels.MyEventsViewModel
 @Composable
 fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsViewModel) {
   val uiState by myEventsViewModel.uiState.collectAsState()
+  myEventsViewModel.fetchMyEvents()
   Scaffold(
       topBar = {
         TopAppBar(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
@@ -51,7 +51,6 @@ import com.monkeyteam.chimpagne.ui.components.ChimpagneButton
 import com.monkeyteam.chimpagne.ui.components.Legend
 import com.monkeyteam.chimpagne.ui.components.SimpleTagChip
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
-import com.monkeyteam.chimpagne.ui.navigation.Route
 import com.monkeyteam.chimpagne.ui.theme.ChimpagneFontFamily
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 
@@ -60,9 +59,6 @@ import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 fun ViewDetailEventScreen(navObject: NavigationActions, eventViewModel: EventViewModel) {
   val uiState by eventViewModel.uiState.collectAsState()
   val context = LocalContext.current
-  eventViewModel.fetchEvent()
-
-  val userRole = eventViewModel.getCurrentUserRole()
 
   Scaffold(
       topBar = {
@@ -133,7 +129,7 @@ fun ViewDetailEventScreen(navObject: NavigationActions, eventViewModel: EventVie
                                     .absolutePadding(left = 16.dp, right = 16.dp)
                                     .testTag("description"))
                         Spacer(Modifier.height(16.dp))
-                        if (userRole != ChimpagneRole.OWNER) {
+                        if (uiState.currentUserRole != ChimpagneRole.OWNER) {
                           ChimpagneButton(
                               text =
                                   stringResource(id = R.string.event_details_screen_leave_button),
@@ -145,8 +141,6 @@ fun ViewDetailEventScreen(navObject: NavigationActions, eventViewModel: EventVie
                                       .fillMaxWidth()
                                       .testTag("leave"),
                               onClick = {
-                                // TODO LEAVE DOES WORk BUT THE MY EVENTS ONLY UPDATES AFTER RE
-                                // ENTRY TO IT
                                 eventViewModel.leaveTheEvent(
                                     onSuccess = {
                                       Toast.makeText(
@@ -156,12 +150,12 @@ fun ViewDetailEventScreen(navObject: NavigationActions, eventViewModel: EventVie
                                                       .event_details_screen_leave_toast_success),
                                               Toast.LENGTH_SHORT)
                                           .show()
-                                      navObject.navigateTo(Route.MY_EVENTS_SCREEN)
+                                      navObject.goBack()
                                     })
                               })
                         }
-                        if (userRole ==
-                            ChimpagneRole.OWNER) { // Only the owner can edit the event settings
+                        // Only the owner can edit the event settings
+                        if (uiState.currentUserRole == ChimpagneRole.OWNER) {
                           ChimpagneButton(
                               text = stringResource(id = R.string.event_details_screen_edit_button),
                               icon = Icons.Rounded.Edit,

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
@@ -63,6 +63,7 @@ fun ViewDetailEventScreen(
 ) {
   val uiState by eventViewModel.uiState.collectAsState()
   val context = LocalContext.current
+  eventViewModel.fetchEvent()
 
   Scaffold(
       topBar = {

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -34,7 +34,7 @@ class EventViewModel(
     fetchEvent(onSuccess, onFailure)
   }
 
-  /* THIS MUST BE CALLED ON EVERY SCREEN THAT USES THE VIEW MODEL */
+  /* THIS MUST BE CALLED IN MAIN ACTIVITY ON TRANSITION TO THE SCREEN THAT USES THE VIEW MODEL */
   fun fetchEvent(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     if (eventID != null) {
       _uiState.value = _uiState.value.copy(loading = true)
@@ -59,6 +59,10 @@ class EventViewModel(
                         it.parkingSpaces,
                         it.beds,
                         it.ownerId)
+                _uiState.value =
+                    _uiState.value.copy(
+                        currentUserRole =
+                            getRole(accountManager.currentUserAccount?.firebaseAuthUID ?: ""))
                 onSuccess()
                 _uiState.value = _uiState.value.copy(loading = false)
               } else {
@@ -74,7 +78,9 @@ class EventViewModel(
       }
     } else {
       _uiState.value =
-          EventUIState(ownerId = accountManager.currentUserAccount?.firebaseAuthUID ?: "")
+          EventUIState(
+              ownerId = accountManager.currentUserAccount?.firebaseAuthUID ?: "",
+              currentUserRole = ChimpagneRole.OWNER)
     }
   }
 
@@ -254,10 +260,6 @@ class EventViewModel(
   fun getRole(userUID: ChimpagneAccountUID): ChimpagneRole {
     return buildChimpagneEvent().getRole(userUID)
   }
-
-  fun getCurrentUserRole(): ChimpagneRole {
-    return getRole(accountManager.currentUserAccount?.firebaseAuthUID ?: "")
-  }
 }
 
 data class EventUIState(
@@ -274,9 +276,9 @@ data class EventUIState(
     val supplies: Map<ChimpagneSupplyId, ChimpagneSupply> = mapOf(),
     val parkingSpaces: Int = 0,
     val beds: Int = 0,
-
-    // unmodifiable the UI
+    // unmodifiable by the UI
     val ownerId: ChimpagneAccountUID = "",
+    val currentUserRole: ChimpagneRole = ChimpagneRole.NOT_IN_EVENT,
     val loading: Boolean = false,
 )
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/MyEventsViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/MyEventsViewModel.kt
@@ -24,8 +24,8 @@ class MyEventsViewModel(
   init {
     fetchMyEvents(onSuccess, onFailure)
   }
-
-  private fun fetchMyEvents(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
+  /* THIS MUST BE CALLED ON EVERY SCREEN THAT USES THE VIEW MODEL */
+  fun fetchMyEvents(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     _uiState.value = _uiState.value.copy(loading = true)
     viewModelScope.launch {
       accountManager.getAllOfMyEvents(

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/MyEventsViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/MyEventsViewModel.kt
@@ -24,7 +24,7 @@ class MyEventsViewModel(
   init {
     fetchMyEvents(onSuccess, onFailure)
   }
-  /* THIS MUST BE CALLED ON EVERY SCREEN THAT USES THE VIEW MODEL */
+  /* THIS MUST BE CALLED IN MAIN ACTIVITY ON TRANSITION TO THE SCREEN THAT USES THE VIEW MODEL */
   fun fetchMyEvents(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     _uiState.value = _uiState.value.copy(loading = true)
     viewModelScope.launch {

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/MyEventsViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/MyEventsViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.database.Database
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,8 +26,7 @@ class MyEventsViewModel(
   }
   /* THIS MUST BE CALLED ON EVERY SCREEN THAT USES THE VIEW MODEL */
   fun fetchMyEvents(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
-    _uiState.value =  _uiState.value.copy(
-            loading = true, userUID = accountManager.currentUserAccount?.firebaseAuthUID!!)
+    _uiState.value = _uiState.value.copy(loading = true)
     viewModelScope.launch {
       accountManager.getAllOfMyEvents(
           { createdEvents, joinedEvents ->
@@ -51,7 +49,6 @@ class MyEventsViewModel(
 data class MyEventsUIState(
     val createdEvents: Map<String, ChimpagneEvent> = emptyMap(),
     val joinedEvents: Map<String, ChimpagneEvent> = emptyMap(),
-    val userUID: ChimpagneAccountUID = "",
     val loading: Boolean = false
 )
 


### PR DESCRIPTION
This PR is meant to fix issue like the one described here: https://github.com/Chimpagne/ChimpagneApp/issues/119 where the UI elements don't update correctly because the view model is being cached and is not fetching the newer information from the database.
The proposed solution here are that now all fetch style functions of view models are made public so that ~the UI can call them when the screen is created / recreated~ we call them when navigation to that screen.