### PR TITLE
AccountManager.getAccounts

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/account/AccountManagerTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/account/AccountManagerTests.kt
@@ -1,0 +1,36 @@
+package com.monkeyteam.chimpagne.newtests.model.account
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccount
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
+import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
+import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AccountManagerTests {
+
+  val database = Database()
+
+  @Before
+  fun init() {
+    initializeTestDatabase()
+  }
+
+  @Test
+  fun getMultipleAccountsTest() {
+    var loading = true
+    var result: Map<ChimpagneAccountUID, ChimpagneAccount?> = hashMapOf()
+    database.accountManager.getAccounts(listOf("JUAN", "PRINCE", "fevoihegijogegjoiejgoi"), { result = it; loading = false }, { assertTrue(false) })
+    while (loading) {}
+
+    assertEquals(TEST_ACCOUNTS[0], result["PRINCE"])
+    assertEquals(TEST_ACCOUNTS[1], result["JUAN"])
+    assertEquals(null, result["fevoihegijogegjoiejgoi"])
+  }
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
@@ -2,15 +2,19 @@ package com.monkeyteam.chimpagne.model.database
 
 import android.net.Uri
 import android.util.Log
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.firestore.toObject
 import com.google.firebase.storage.StorageReference
 
 /** Use this class to interact */
 class ChimpagneAccountManager(
-    private val database: Database,
-    private val accounts: CollectionReference,
-    private val profilePictures: StorageReference
+  private val database: Database,
+  private val accounts: CollectionReference,
+  private val profilePictures: StorageReference
 ) {
 
   /**
@@ -50,104 +54,100 @@ class ChimpagneAccountManager(
    * @param onFailure(exception) Called in case of... failure
    */
   fun getAccount(
-      uid: ChimpagneAccountUID,
-      onSuccess: (ChimpagneAccount?) -> Unit,
-      onFailure: (Exception) -> Unit
+    uid: ChimpagneAccountUID, onSuccess: (ChimpagneAccount?) -> Unit, onFailure: (Exception) -> Unit
   ) {
-    accounts
-        .document(uid)
-        .get()
-        .addOnSuccessListener { onSuccess(it.toObject<ChimpagneAccount>()) }
-        .addOnFailureListener { onFailure(it) }
+    accounts.document(uid).get().addOnSuccessListener { onSuccess(it.toObject<ChimpagneAccount>()) }
+      .addOnFailureListener { onFailure(it) }
   }
 
   fun getAccountWithProfilePicture(
-      uid: ChimpagneAccountUID,
-      onSuccess: (ChimpagneAccount?, Uri?) -> Unit,
-      onFailure: (Exception) -> Unit
+    uid: ChimpagneAccountUID,
+    onSuccess: (ChimpagneAccount?, Uri?) -> Unit,
+    onFailure: (Exception) -> Unit
   ) {
     getAccount(
-        uid,
-        { account ->
-          if (account == null) onSuccess(null, null)
-          else
-              downloadProfilePicture(
-                  account.firebaseAuthUID,
-              ) { uri ->
-                onSuccess(account, uri)
-              }
-        },
-        onFailure)
+      uid, { account ->
+        if (account == null) onSuccess(null, null)
+        else downloadProfilePicture(
+          account.firebaseAuthUID,
+        ) { uri ->
+          onSuccess(account, uri)
+        }
+      }, onFailure
+    )
+  }
+
+  fun getAccounts(
+    uidList: List<ChimpagneAccountUID>,
+    onSuccess: (Map<ChimpagneAccountUID, ChimpagneAccount?>) -> Unit,
+    onFailure: (Exception) -> Unit
+  ) {
+    val tasks: Map<ChimpagneAccountUID, Task<DocumentSnapshot>> = uidList.map {
+      (it to accounts.document(it).get())
+    }.toMap()
+    Tasks.whenAllComplete(tasks.values).addOnSuccessListener {
+      val results = tasks.map {
+        val account = it.value.result.toObject<ChimpagneAccount>()
+        (it.key to account)
+      }.toMap()
+      onSuccess(results)
+    }.addOnFailureListener(onFailure)
   }
 
   /** Puts the given account to Firebase and updates [currentUserAccount] accordingly */
   fun updateCurrentAccount(
-      account: ChimpagneAccount,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
+    account: ChimpagneAccount, onSuccess: () -> Unit, onFailure: (Exception) -> Unit
   ) {
-    accounts
-        .document(account.firebaseAuthUID)
-        .set(account)
-        .addOnSuccessListener {
-          currentUserAccount = account
-          onSuccess()
-        }
-        .addOnFailureListener { onFailure(it) }
+    accounts.document(account.firebaseAuthUID).set(account).addOnSuccessListener {
+        currentUserAccount = account
+        onSuccess()
+      }.addOnFailureListener { onFailure(it) }
   }
 
   fun updateCurrentAccount(
-      account: ChimpagneAccount,
-      profilePicture: Uri?,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
+    account: ChimpagneAccount,
+    profilePicture: Uri?,
+    onSuccess: () -> Unit,
+    onFailure: (Exception) -> Unit
   ) {
     if (profilePicture == null) {
       updateCurrentAccount(account, onSuccess, onFailure)
     } else {
       uploadProfilePicture(
-          account,
-          profilePicture,
-          { updateCurrentAccount(account, onSuccess, onFailure) },
-          onFailure)
+        account, profilePicture, { updateCurrentAccount(account, onSuccess, onFailure) }, onFailure
+      )
     }
   }
 
   private fun uploadProfilePicture(
-      account: ChimpagneAccount,
-      uri: Uri,
-      onSuccess: (String) -> Unit,
-      onFailure: (Exception) -> Unit
+    account: ChimpagneAccount, uri: Uri, onSuccess: (String) -> Unit, onFailure: (Exception) -> Unit
   ) {
     //    profilePictures.child(account.firebaseAuthUID).delete()
     val imageRef = profilePictures.child(account.firebaseAuthUID)
-    imageRef
-        .putFile(uri)
-        .addOnSuccessListener {
-          imageRef.downloadUrl.addOnSuccessListener { downloadUrl ->
-            Log.d("ChimpagneAccountManager", "Uploaded image to: $downloadUrl")
-            onSuccess(downloadUrl.toString())
-          }
+    imageRef.putFile(uri).addOnSuccessListener {
+        imageRef.downloadUrl.addOnSuccessListener { downloadUrl ->
+          Log.d("ChimpagneAccountManager", "Uploaded image to: $downloadUrl")
+          onSuccess(downloadUrl.toString())
         }
-        .addOnFailureListener { onFailure(it) }
+      }.addOnFailureListener { onFailure(it) }
   }
 
   private fun downloadProfilePicture(uid: String, onSuccess: (Uri?) -> Unit) {
-    profilePictures
-        .child(uid)
-        .downloadUrl
-        .addOnSuccessListener { downloadedURI -> onSuccess(downloadedURI) }
-        .addOnFailureListener { onSuccess(null) }
+    profilePictures.child(uid).downloadUrl.addOnSuccessListener { downloadedURI ->
+        onSuccess(
+          downloadedURI
+        )
+      }.addOnFailureListener { onSuccess(null) }
   }
 
   private val eventManager = database.eventManager
 
   /** @param role: ChimpagneRole (for instance ChimpagneRoles.GUEST) */
   fun joinEvent(
-      id: ChimpagneEventId,
-      role: ChimpagneRole,
-      onSuccess: () -> Unit = {},
-      onFailure: (Exception) -> Unit = {}
+    id: ChimpagneEventId,
+    role: ChimpagneRole,
+    onSuccess: () -> Unit = {},
+    onFailure: (Exception) -> Unit = {}
   ) {
     if (currentUserAccount == null) {
       onFailure(NotLoggedInException())
@@ -155,31 +155,31 @@ class ChimpagneAccountManager(
     }
 
     val updatedAccount =
-        currentUserAccount!!.copy(joinedEvents = currentUserAccount!!.joinedEvents + (id to true))
+      currentUserAccount!!.copy(joinedEvents = currentUserAccount!!.joinedEvents + (id to true))
     when (role) {
-      ChimpagneRole.GUEST ->
-          eventManager.addGuest(
-              id,
-              updatedAccount.firebaseAuthUID,
-              { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
-              onFailure)
-      ChimpagneRole.STAFF ->
-          eventManager.addStaff(
-              id,
-              updatedAccount.firebaseAuthUID,
-              { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
-              onFailure)
+      ChimpagneRole.GUEST -> eventManager.addGuest(
+        id,
+        updatedAccount.firebaseAuthUID,
+        { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
+        onFailure
+      )
+
+      ChimpagneRole.STAFF -> eventManager.addStaff(
+        id,
+        updatedAccount.firebaseAuthUID,
+        { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
+        onFailure
+      )
+
       ChimpagneRole.OWNER -> updateCurrentAccount(updatedAccount, onSuccess, onFailure)
-      ChimpagneRole.NOT_IN_EVENT ->
-          onFailure(
-              Exception("Joining an event with ChimpagneRole.NOT_IN_EVENT ! Are you stupid ?"))
+      ChimpagneRole.NOT_IN_EVENT -> onFailure(
+        Exception("Joining an event with ChimpagneRole.NOT_IN_EVENT ! Are you stupid ?")
+      )
     }
   }
 
   fun leaveEvent(
-      id: ChimpagneEventId,
-      onSuccess: () -> Unit = {},
-      onFailure: (Exception) -> Unit = {}
+    id: ChimpagneEventId, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}
   ) {
     if (currentUserAccount == null) {
       onFailure(NotLoggedInException())
@@ -187,24 +187,23 @@ class ChimpagneAccountManager(
     }
 
     val updatedAccount =
-        currentUserAccount!!.copy(joinedEvents = currentUserAccount!!.joinedEvents - id)
+      currentUserAccount!!.copy(joinedEvents = currentUserAccount!!.joinedEvents - id)
 
     eventManager.removeGuest(
-        id,
-        updatedAccount.firebaseAuthUID,
-        {
-          eventManager.removeStaff(
-              id,
-              updatedAccount.firebaseAuthUID,
-              { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
-              onFailure)
-        },
-        onFailure)
+      id, updatedAccount.firebaseAuthUID, {
+        eventManager.removeStaff(
+          id,
+          updatedAccount.firebaseAuthUID,
+          { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
+          onFailure
+        )
+      }, onFailure
+    )
   }
 
   fun getAllOfMyEvents(
-      onSuccess: (createdEvents: List<ChimpagneEvent>, joinedEvents: List<ChimpagneEvent>) -> Unit,
-      onFailure: (Exception) -> Unit
+    onSuccess: (createdEvents: List<ChimpagneEvent>, joinedEvents: List<ChimpagneEvent>) -> Unit,
+    onFailure: (Exception) -> Unit
   ) {
     if (database.accountManager.currentUserAccount == null) {
       return onFailure(NotLoggedInException())
@@ -215,21 +214,19 @@ class ChimpagneAccountManager(
       return onSuccess(emptyList(), emptyList())
     }
 
-    database.eventManager.getEvents(
-        eventIDs.keys.toList(),
-        {
-          val joinedEvents: MutableList<ChimpagneEvent> = ArrayList()
-          val createdEvents: MutableList<ChimpagneEvent> = ArrayList()
+    database.eventManager.getEvents(eventIDs.keys.toList(), {
+      val joinedEvents: MutableList<ChimpagneEvent> = ArrayList()
+      val createdEvents: MutableList<ChimpagneEvent> = ArrayList()
 
-          for (event in it) {
-            if (event.ownerId == database.accountManager.currentUserAccount!!.firebaseAuthUID)
-                createdEvents.add(event)
-            else joinedEvents.add(event)
-          }
+      for (event in it) {
+        if (event.ownerId == database.accountManager.currentUserAccount!!.firebaseAuthUID) createdEvents.add(
+          event
+        )
+        else joinedEvents.add(event)
+      }
 
-          onSuccess(createdEvents, joinedEvents)
-        },
-        { onFailure(it) })
+      onSuccess(createdEvents, joinedEvents)
+    }, { onFailure(it) })
   }
 }
 


### PR DESCRIPTION
This simple PR adds the method getAccounts to the AccountManager class. This method works the same ways as getAccount but allows to fetch multiple accounts at the same time. Hence, its success callbacks takes a Map<ChimpagneAccountUID, ChimpagneAccount?> rather than a ChimpagneAccount?.