### PR TITLE
☢ Atom protects us from race conditions ⚛

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/EventTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/EventTest.kt
@@ -2,12 +2,36 @@ package com.monkeyteam.chimpagne.newtests.model.event
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
+import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
+import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
+import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
+import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class EventTest {
+
+  val database = Database()
+  val accountManager = database.accountManager
+  val eventManager = database.eventManager
+
+//  val ownerOfEvent0 = TEST_ACCOUNTS[1]
+  val event = TEST_EVENTS[0]
+  val account0 = TEST_ACCOUNTS[0]
+  val account1 = TEST_ACCOUNTS[1]
+  val account2 = TEST_ACCOUNTS[2]
+
+  @Before
+  fun init() {
+    initializeTestDatabase()
+    accountManager.signInTo((account0))
+  }
 
   @Test
   fun guestListAndStaffListTest() {
@@ -16,5 +40,57 @@ class EventTest {
             staffs = hashMapOf("1" to true, "2" to true), guests = hashMapOf("3" to true))
     assertEquals(event.guests.keys, event.guestList())
     assertEquals(event.staffs.keys, event.staffList())
+  }
+
+  @Test
+  fun supplyTest() {
+    val supply = ChimpagneSupply(
+      description = "bananas from la Migros",
+      quantity = 4,
+      unit = "bananas",
+      assignedTo = hashMapOf(account0.firebaseAuthUID to true, account1.firebaseAuthUID to true)
+    )
+
+    var loading = true
+    eventManager.atomic.updateSupply(event.id, supply, { loading = false }, { assertTrue(false) })
+    while (loading)  {}
+    var updatedEvent = ChimpagneEvent()
+    loading = true
+    eventManager.getEventById(event.id, { updatedEvent = it!!; loading = false }, { assertTrue(false) })
+    while (loading)  {}
+
+    assertEquals(supply, updatedEvent.supplies[supply.id])
+
+    loading = true
+    eventManager.atomic.removeSupply(event.id, supply.id, { loading = false }, { assertTrue(false) })
+    while (loading)  {}
+    updatedEvent = ChimpagneEvent()
+    loading = true
+    eventManager.getEventById(event.id, { updatedEvent = it!!; loading = false }, { assertTrue(false) })
+    while (loading)  {}
+
+    assertEquals(null, updatedEvent.supplies[supply.id])
+
+    loading = true
+    eventManager.atomic.updateSupply(event.id, supply, { loading = false }, { assertTrue(false) })
+    while (loading)  {}
+    updatedEvent = ChimpagneEvent()
+    loading = true
+    eventManager.atomic.assignSupply(event.id, supply.id, account2.firebaseAuthUID,  { loading = false }, { assertTrue(false) })
+    while (loading) {}
+    loading = true
+    eventManager.getEventById(event.id, { updatedEvent = it!!; loading = false }, { assertTrue(false) })
+    while (loading)  {}
+
+    assertTrue(updatedEvent.supplies[supply.id]!!.assignedTo[account2.firebaseAuthUID] == true)
+
+    loading = true
+    eventManager.atomic.unassignSupply(event.id, supply.id, account2.firebaseAuthUID,  { loading = false }, { assertTrue(false) })
+    while (loading) {}
+    loading = true
+    eventManager.getEventById(event.id, { updatedEvent = it!!; loading = false }, { assertTrue(false) })
+    while (loading)  {}
+
+    assertNull(updatedEvent.supplies[supply.id]!!.assignedTo[account2.firebaseAuthUID])
   }
 }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/EventTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/EventTest.kt
@@ -55,6 +55,7 @@ class EventTest {
     var loading = true
     eventManager.atomic.updateSupply(event.id, supply, { loading = false }, { assertTrue(false) })
     while (loading) {}
+    Thread.sleep(100)
     var updatedEvent = ChimpagneEvent()
     loading = true
     eventManager.getEventById(
@@ -72,6 +73,7 @@ class EventTest {
     eventManager.atomic.removeSupply(
         event.id, supply.id, { loading = false }, { assertTrue(false) })
     while (loading) {}
+    Thread.sleep(100)
     updatedEvent = ChimpagneEvent()
     loading = true
     eventManager.getEventById(
@@ -82,7 +84,7 @@ class EventTest {
         },
         { assertTrue(false) })
     while (loading) {}
-
+    Thread.sleep(100)
     assertEquals(null, updatedEvent.supplies[supply.id])
 
     loading = true
@@ -93,6 +95,7 @@ class EventTest {
     eventManager.atomic.assignSupply(
         event.id, supply.id, account2.firebaseAuthUID, { loading = false }, { assertTrue(false) })
     while (loading) {}
+    Thread.sleep(100)
     loading = true
     eventManager.getEventById(
         event.id,
@@ -109,6 +112,7 @@ class EventTest {
     eventManager.atomic.unassignSupply(
         event.id, supply.id, account2.firebaseAuthUID, { loading = false }, { assertTrue(false) })
     while (loading) {}
+    Thread.sleep(100)
     loading = true
     eventManager.getEventById(
         event.id,

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/EventTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/EventTest.kt
@@ -21,7 +21,7 @@ class EventTest {
   val accountManager = database.accountManager
   val eventManager = database.eventManager
 
-//  val ownerOfEvent0 = TEST_ACCOUNTS[1]
+  //  val ownerOfEvent0 = TEST_ACCOUNTS[1]
   val event = TEST_EVENTS[0]
   val account0 = TEST_ACCOUNTS[0]
   val account1 = TEST_ACCOUNTS[1]
@@ -44,52 +44,80 @@ class EventTest {
 
   @Test
   fun supplyTest() {
-    val supply = ChimpagneSupply(
-      description = "bananas from la Migros",
-      quantity = 4,
-      unit = "bananas",
-      assignedTo = hashMapOf(account0.firebaseAuthUID to true, account1.firebaseAuthUID to true)
-    )
+    val supply =
+        ChimpagneSupply(
+            description = "bananas from la Migros",
+            quantity = 4,
+            unit = "bananas",
+            assignedTo =
+                hashMapOf(account0.firebaseAuthUID to true, account1.firebaseAuthUID to true))
 
     var loading = true
     eventManager.atomic.updateSupply(event.id, supply, { loading = false }, { assertTrue(false) })
-    while (loading)  {}
+    while (loading) {}
     var updatedEvent = ChimpagneEvent()
     loading = true
-    eventManager.getEventById(event.id, { updatedEvent = it!!; loading = false }, { assertTrue(false) })
-    while (loading)  {}
+    eventManager.getEventById(
+        event.id,
+        {
+          updatedEvent = it!!
+          loading = false
+        },
+        { assertTrue(false) })
+    while (loading) {}
 
     assertEquals(supply, updatedEvent.supplies[supply.id])
 
     loading = true
-    eventManager.atomic.removeSupply(event.id, supply.id, { loading = false }, { assertTrue(false) })
-    while (loading)  {}
+    eventManager.atomic.removeSupply(
+        event.id, supply.id, { loading = false }, { assertTrue(false) })
+    while (loading) {}
     updatedEvent = ChimpagneEvent()
     loading = true
-    eventManager.getEventById(event.id, { updatedEvent = it!!; loading = false }, { assertTrue(false) })
-    while (loading)  {}
+    eventManager.getEventById(
+        event.id,
+        {
+          updatedEvent = it!!
+          loading = false
+        },
+        { assertTrue(false) })
+    while (loading) {}
 
     assertEquals(null, updatedEvent.supplies[supply.id])
 
     loading = true
     eventManager.atomic.updateSupply(event.id, supply, { loading = false }, { assertTrue(false) })
-    while (loading)  {}
+    while (loading) {}
     updatedEvent = ChimpagneEvent()
     loading = true
-    eventManager.atomic.assignSupply(event.id, supply.id, account2.firebaseAuthUID,  { loading = false }, { assertTrue(false) })
+    eventManager.atomic.assignSupply(
+        event.id, supply.id, account2.firebaseAuthUID, { loading = false }, { assertTrue(false) })
     while (loading) {}
     loading = true
-    eventManager.getEventById(event.id, { updatedEvent = it!!; loading = false }, { assertTrue(false) })
-    while (loading)  {}
+    eventManager.getEventById(
+        event.id,
+        {
+          updatedEvent = it!!
+          loading = false
+        },
+        { assertTrue(false) })
+    while (loading) {}
 
     assertTrue(updatedEvent.supplies[supply.id]!!.assignedTo[account2.firebaseAuthUID] == true)
 
     loading = true
-    eventManager.atomic.unassignSupply(event.id, supply.id, account2.firebaseAuthUID,  { loading = false }, { assertTrue(false) })
+    eventManager.atomic.unassignSupply(
+        event.id, supply.id, account2.firebaseAuthUID, { loading = false }, { assertTrue(false) })
     while (loading) {}
     loading = true
-    eventManager.getEventById(event.id, { updatedEvent = it!!; loading = false }, { assertTrue(false) })
-    while (loading)  {}
+    eventManager.getEventById(
+        event.id,
+        {
+          updatedEvent = it!!
+          loading = false
+        },
+        { assertTrue(false) })
+    while (loading) {}
 
     assertNull(updatedEvent.supplies[supply.id]!!.assignedTo[account2.firebaseAuthUID])
   }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/JoinEventTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/JoinEventTests.kt
@@ -49,7 +49,7 @@ class JoinEventTests {
     assertEquals(ChimpagneRole.NOT_IN_EVENT, event.getRole(anotherAccount.firebaseAuthUID))
 
     var loading = true
-    eventManager.addGuest(
+    eventManager.atomic.addGuest(
         eventId,
         anotherAccount.firebaseAuthUID,
         { loading = false },

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/AtomicChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/AtomicChimpagneEventManager.kt
@@ -1,0 +1,77 @@
+package com.monkeyteam.chimpagne.model.database
+
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.FieldValue
+
+class AtomicChimpagneEventManager(
+  private val database: Database,
+  private val events: CollectionReference
+) {
+  internal fun addGuest(
+    eventId: ChimpagneEventId,
+    userUID: ChimpagneAccountUID,
+    onSuccess: () -> Unit,
+    onFailure: (Exception) -> Unit
+  ) {
+    events
+      .document(eventId)
+      .update("guests.${userUID}", true)
+      .addOnSuccessListener { onSuccess() }
+      .addOnFailureListener { onFailure(it) }
+  }
+
+  internal fun removeGuest(
+    eventId: ChimpagneEventId,
+    userUID: ChimpagneAccountUID,
+    onSuccess: () -> Unit,
+    onFailure: (Exception) -> Unit
+  ) {
+    events
+      .document(eventId)
+      .update("guests.${userUID}", FieldValue.delete())
+      .addOnSuccessListener { onSuccess() }
+      .addOnFailureListener { onFailure(it) }
+  }
+
+  internal fun addStaff(
+    eventId: ChimpagneEventId,
+    userUID: ChimpagneAccountUID,
+    onSuccess: () -> Unit,
+    onFailure: (Exception) -> Unit
+  ) {
+    events
+      .document(eventId)
+      .update("staffs.${userUID}", true)
+      .addOnSuccessListener { onSuccess() }
+      .addOnFailureListener { onFailure(it) }
+  }
+
+  internal fun removeStaff(
+    eventId: ChimpagneEventId,
+    userUID: ChimpagneAccountUID,
+    onSuccess: () -> Unit,
+    onFailure: (Exception) -> Unit
+  ) {
+    events
+      .document(eventId)
+      .update("staffs.${userUID}", FieldValue.delete())
+      .addOnSuccessListener { onSuccess() }
+      .addOnFailureListener { onFailure(it) }
+  }
+
+  fun updateSupply(eventId: ChimpagneEventId, supply: ChimpagneSupply, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
+    events.document(eventId).update("supplies.${supply.id}", supply).addOnSuccessListener { onSuccess() } .addOnFailureListener(onFailure)
+  }
+
+  fun removeSupply(eventId: ChimpagneEventId, supplyId: ChimpagneSupplyId, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
+    events.document(eventId).update("supplies.${supplyId}", FieldValue.delete()).addOnSuccessListener { onSuccess() } .addOnFailureListener(onFailure)
+  }
+
+  fun assignSupply(eventId: ChimpagneEventId, supplyId: ChimpagneSupplyId, accountUID: ChimpagneAccountUID, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
+    events.document(eventId).update("supplies.$supplyId.assignedTo.$accountUID", true).addOnSuccessListener { onSuccess() } .addOnFailureListener(onFailure)
+  }
+
+  fun unassignSupply(eventId: ChimpagneEventId, supplyId: ChimpagneSupplyId, accountUID: ChimpagneAccountUID, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
+    events.document(eventId).update("supplies.$supplyId.assignedTo.$accountUID", FieldValue.delete()).addOnSuccessListener { onSuccess() } .addOnFailureListener(onFailure)
+  }
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/AtomicChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/AtomicChimpagneEventManager.kt
@@ -4,74 +4,112 @@ import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.FieldValue
 
 class AtomicChimpagneEventManager(
-  private val database: Database,
-  private val events: CollectionReference
+    private val database: Database,
+    private val events: CollectionReference
 ) {
   internal fun addGuest(
-    eventId: ChimpagneEventId,
-    userUID: ChimpagneAccountUID,
-    onSuccess: () -> Unit,
-    onFailure: (Exception) -> Unit
+      eventId: ChimpagneEventId,
+      userUID: ChimpagneAccountUID,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
   ) {
     events
-      .document(eventId)
-      .update("guests.${userUID}", true)
-      .addOnSuccessListener { onSuccess() }
-      .addOnFailureListener { onFailure(it) }
+        .document(eventId)
+        .update("guests.${userUID}", true)
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { onFailure(it) }
   }
 
   internal fun removeGuest(
-    eventId: ChimpagneEventId,
-    userUID: ChimpagneAccountUID,
-    onSuccess: () -> Unit,
-    onFailure: (Exception) -> Unit
+      eventId: ChimpagneEventId,
+      userUID: ChimpagneAccountUID,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
   ) {
     events
-      .document(eventId)
-      .update("guests.${userUID}", FieldValue.delete())
-      .addOnSuccessListener { onSuccess() }
-      .addOnFailureListener { onFailure(it) }
+        .document(eventId)
+        .update("guests.${userUID}", FieldValue.delete())
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { onFailure(it) }
   }
 
   internal fun addStaff(
-    eventId: ChimpagneEventId,
-    userUID: ChimpagneAccountUID,
-    onSuccess: () -> Unit,
-    onFailure: (Exception) -> Unit
+      eventId: ChimpagneEventId,
+      userUID: ChimpagneAccountUID,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
   ) {
     events
-      .document(eventId)
-      .update("staffs.${userUID}", true)
-      .addOnSuccessListener { onSuccess() }
-      .addOnFailureListener { onFailure(it) }
+        .document(eventId)
+        .update("staffs.${userUID}", true)
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { onFailure(it) }
   }
 
   internal fun removeStaff(
-    eventId: ChimpagneEventId,
-    userUID: ChimpagneAccountUID,
-    onSuccess: () -> Unit,
-    onFailure: (Exception) -> Unit
+      eventId: ChimpagneEventId,
+      userUID: ChimpagneAccountUID,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
   ) {
     events
-      .document(eventId)
-      .update("staffs.${userUID}", FieldValue.delete())
-      .addOnSuccessListener { onSuccess() }
-      .addOnFailureListener { onFailure(it) }
+        .document(eventId)
+        .update("staffs.${userUID}", FieldValue.delete())
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { onFailure(it) }
   }
 
-  fun updateSupply(eventId: ChimpagneEventId, supply: ChimpagneSupply, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
-    events.document(eventId).update("supplies.${supply.id}", supply).addOnSuccessListener { onSuccess() } .addOnFailureListener(onFailure)
+  fun updateSupply(
+      eventId: ChimpagneEventId,
+      supply: ChimpagneSupply,
+      onSuccess: () -> Unit = {},
+      onFailure: (Exception) -> Unit = {}
+  ) {
+    events
+        .document(eventId)
+        .update("supplies.${supply.id}", supply)
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener(onFailure)
   }
 
-  fun removeSupply(eventId: ChimpagneEventId, supplyId: ChimpagneSupplyId, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
-    events.document(eventId).update("supplies.${supplyId}", FieldValue.delete()).addOnSuccessListener { onSuccess() } .addOnFailureListener(onFailure)
+  fun removeSupply(
+      eventId: ChimpagneEventId,
+      supplyId: ChimpagneSupplyId,
+      onSuccess: () -> Unit = {},
+      onFailure: (Exception) -> Unit = {}
+  ) {
+    events
+        .document(eventId)
+        .update("supplies.${supplyId}", FieldValue.delete())
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener(onFailure)
   }
 
-  fun assignSupply(eventId: ChimpagneEventId, supplyId: ChimpagneSupplyId, accountUID: ChimpagneAccountUID, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
-    events.document(eventId).update("supplies.$supplyId.assignedTo.$accountUID", true).addOnSuccessListener { onSuccess() } .addOnFailureListener(onFailure)
+  fun assignSupply(
+      eventId: ChimpagneEventId,
+      supplyId: ChimpagneSupplyId,
+      accountUID: ChimpagneAccountUID,
+      onSuccess: () -> Unit = {},
+      onFailure: (Exception) -> Unit = {}
+  ) {
+    events
+        .document(eventId)
+        .update("supplies.$supplyId.assignedTo.$accountUID", true)
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener(onFailure)
   }
 
-  fun unassignSupply(eventId: ChimpagneEventId, supplyId: ChimpagneSupplyId, accountUID: ChimpagneAccountUID, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
-    events.document(eventId).update("supplies.$supplyId.assignedTo.$accountUID", FieldValue.delete()).addOnSuccessListener { onSuccess() } .addOnFailureListener(onFailure)
+  fun unassignSupply(
+      eventId: ChimpagneEventId,
+      supplyId: ChimpagneSupplyId,
+      accountUID: ChimpagneAccountUID,
+      onSuccess: () -> Unit = {},
+      onFailure: (Exception) -> Unit = {}
+  ) {
+    events
+        .document(eventId)
+        .update("supplies.$supplyId.assignedTo.$accountUID", FieldValue.delete())
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener(onFailure)
   }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/AtomicChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/AtomicChimpagneEventManager.kt
@@ -7,7 +7,7 @@ class AtomicChimpagneEventManager(
     private val database: Database,
     private val events: CollectionReference
 ) {
-  internal fun addGuest(
+  fun addGuest(
       eventId: ChimpagneEventId,
       userUID: ChimpagneAccountUID,
       onSuccess: () -> Unit,
@@ -20,7 +20,7 @@ class AtomicChimpagneEventManager(
         .addOnFailureListener { onFailure(it) }
   }
 
-  internal fun removeGuest(
+  fun removeGuest(
       eventId: ChimpagneEventId,
       userUID: ChimpagneAccountUID,
       onSuccess: () -> Unit,
@@ -33,7 +33,7 @@ class AtomicChimpagneEventManager(
         .addOnFailureListener { onFailure(it) }
   }
 
-  internal fun addStaff(
+  fun addStaff(
       eventId: ChimpagneEventId,
       userUID: ChimpagneAccountUID,
       onSuccess: () -> Unit,
@@ -46,7 +46,7 @@ class AtomicChimpagneEventManager(
         .addOnFailureListener { onFailure(it) }
   }
 
-  internal fun removeStaff(
+  fun removeStaff(
       eventId: ChimpagneEventId,
       userUID: ChimpagneAccountUID,
       onSuccess: () -> Unit,

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
@@ -182,13 +182,13 @@ class ChimpagneAccountManager(
         currentUserAccount!!.copy(joinedEvents = currentUserAccount!!.joinedEvents + (id to true))
     when (role) {
       ChimpagneRole.GUEST ->
-          eventManager.addGuest(
+          eventManager.atomic.addGuest(
               id,
               updatedAccount.firebaseAuthUID,
               { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
               onFailure)
       ChimpagneRole.STAFF ->
-          eventManager.addStaff(
+          eventManager.atomic.addStaff(
               id,
               updatedAccount.firebaseAuthUID,
               { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },
@@ -213,11 +213,11 @@ class ChimpagneAccountManager(
     val updatedAccount =
         currentUserAccount!!.copy(joinedEvents = currentUserAccount!!.joinedEvents - id)
 
-    eventManager.removeGuest(
+    eventManager.atomic.removeGuest(
         id,
         updatedAccount.firebaseAuthUID,
         {
-          eventManager.removeStaff(
+          eventManager.atomic.removeStaff(
               id,
               updatedAccount.firebaseAuthUID,
               { updateCurrentAccount(updatedAccount, onSuccess, onFailure) },

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
@@ -5,7 +5,6 @@ import com.firebase.geofire.GeoLocation
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.CollectionReference
-import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.Filter
 import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.firestore.toObject

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
@@ -15,6 +15,8 @@ class ChimpagneEventManager(
     private val database: Database,
     private val events: CollectionReference
 ) {
+  val atomic = AtomicChimpagneEventManager(database, events)
+
   fun getAllEventsByFilterAroundLocation(
       center: Location,
       radiusInM: Double,
@@ -117,58 +119,6 @@ class ChimpagneEventManager(
     events
         .document(id)
         .delete()
-        .addOnSuccessListener { onSuccess() }
-        .addOnFailureListener { onFailure(it) }
-  }
-
-  internal fun addGuest(
-      eventId: ChimpagneEventId,
-      userUID: ChimpagneAccountUID,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    events
-        .document(eventId)
-        .update("guests.${userUID}", true)
-        .addOnSuccessListener { onSuccess() }
-        .addOnFailureListener { onFailure(it) }
-  }
-
-  internal fun removeGuest(
-      eventId: ChimpagneEventId,
-      userUID: ChimpagneAccountUID,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    events
-        .document(eventId)
-        .update("guests.${userUID}", FieldValue.delete())
-        .addOnSuccessListener { onSuccess() }
-        .addOnFailureListener { onFailure(it) }
-  }
-
-  internal fun addStaff(
-      eventId: ChimpagneEventId,
-      userUID: ChimpagneAccountUID,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    events
-        .document(eventId)
-        .update("staffs.${userUID}", true)
-        .addOnSuccessListener { onSuccess() }
-        .addOnFailureListener { onFailure(it) }
-  }
-
-  internal fun removeStaff(
-      eventId: ChimpagneEventId,
-      userUID: ChimpagneAccountUID,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    events
-        .document(eventId)
-        .update("staffs.${userUID}", FieldValue.delete())
         .addOnSuccessListener { onSuccess() }
         .addOnFailureListener { onFailure(it) }
   }


### PR DESCRIPTION
This PR solves an important concurrency issue happening if multiple devices are displaying and interacting with the same event using the power of atom !
More seriously, you can now access ChimpagneEventManager methods said "atomic" (i.e. methods that update only one field instead of rewriting an entire object) using `ChimpagneEventManager.atomic.<method name>` . Please use those methods to interact with events that are already created and on the database.