### PR TITLE
time is merely a construct, fix issue #157

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/TestUtils.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/TestUtils.kt
@@ -15,6 +15,8 @@ import com.monkeyteam.chimpagne.model.database.TEST_TABLES
 import com.monkeyteam.chimpagne.model.location.Location
 import com.monkeyteam.chimpagne.model.utils.buildTimestamp
 
+val DELAY_AMOUNT_MILLIS: Long = 300
+
 val TEST_EVENTS =
     listOf(
         ChimpagneEvent(

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/TestUtils.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/TestUtils.kt
@@ -15,7 +15,7 @@ import com.monkeyteam.chimpagne.model.database.TEST_TABLES
 import com.monkeyteam.chimpagne.model.location.Location
 import com.monkeyteam.chimpagne.model.utils.buildTimestamp
 
-val DELAY_AMOUNT_MILLIS: Long = 300
+val SLEEP_AMOUNT_MILLIS: Long = 300
 
 val TEST_EVENTS =
     listOf(

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -5,11 +5,14 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.monkeyteam.chimpagne.model.database.ChimpagneAccount
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.newtests.DELAY_AMOUNT_MILLIS
 import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
 import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
 import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -95,6 +98,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventCreationVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     val eventID = eventCreationVM.uiState.value.id
 
@@ -107,6 +111,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     assertEqualEventVMWithEvent(eventSearchVM, testEvent)
 
@@ -115,6 +120,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     assertTrue(eventSearchVM.uiState.value.id == "")
   }
@@ -130,6 +136,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventCreationVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     val eventID = eventCreationVM.uiState.value.id
 
@@ -142,6 +149,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     assertTrue(eventSearchVM.uiState.value.id == eventID)
 
@@ -153,6 +161,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     val eventSearch2VM =
         EventViewModel(
@@ -163,11 +172,14 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearch2VM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
-    // assertEqualEventVMWithEvent(eventSearch2VM, testUpdateEvent)
+    assertEqualEventVMWithEvent(eventSearch2VM, testUpdateEvent)
 
     eventSearch2VM.deleteTheEvent(
         onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
+    while (eventSearch2VM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
   }
 
   @Test
@@ -181,6 +193,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventCreationVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     val eventID = eventCreationVM.uiState.value.id
 
@@ -193,20 +206,24 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     assertTrue(eventSearchVM.uiState.value.guests.isEmpty())
 
     changeAccount(TEST_ACCOUNTS[0])
     eventSearchVM.joinTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     changeAccount(TEST_ACCOUNTS[1])
     eventSearchVM.joinTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     changeAccount(TEST_ACCOUNTS[2])
     eventSearchVM.joinTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     assertTrue(eventSearchVM.uiState.value.guests.size == 3)
     assertTrue(
@@ -219,18 +236,23 @@ class EventViewModelTests {
 
     eventSearchVM.leaveTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     changeAccount(TEST_ACCOUNTS[1])
     eventSearchVM.leaveTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     changeAccount(TEST_ACCOUNTS[0])
     eventSearchVM.leaveTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     assertTrue(eventSearchVM.uiState.value.guests.isEmpty())
 
     eventSearchVM.deleteTheEvent(
         onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
+    while (eventSearchVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
   }
 }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -2,17 +2,13 @@ package com.monkeyteam.chimpagne.newtests.viewmodels
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.monkeyteam.chimpagne.model.database.ChimpagneAccount
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.database.Database
-import com.monkeyteam.chimpagne.newtests.DELAY_AMOUNT_MILLIS
+import com.monkeyteam.chimpagne.newtests.SLEEP_AMOUNT_MILLIS
 import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
 import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
-import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -25,19 +21,13 @@ class EventViewModelTests {
 
   @Before
   fun signIn() {
-    changeAccount(TEST_ACCOUNTS[1])
+    database.accountManager.signInTo(TEST_ACCOUNTS[1])
   }
 
   @get:Rule val composeTestRule = createComposeRule()
 
   private val testEvent = TEST_EVENTS[0]
   private val testUpdateEvent = TEST_EVENTS[1]
-
-  private fun changeAccount(account: ChimpagneAccount) {
-    val accountViewModel = AccountViewModel(database = database)
-    accountViewModel.loginToChimpagneAccount(account.firebaseAuthUID, {}, {})
-    while (accountViewModel.uiState.value.loading) {}
-  }
 
   private fun replaceVMEventBy(eventVM: EventViewModel, event: ChimpagneEvent) {
     eventVM.updateEventTitle(event.title)
@@ -98,7 +88,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventCreationVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     val eventID = eventCreationVM.uiState.value.id
 
@@ -111,7 +101,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     assertEqualEventVMWithEvent(eventSearchVM, testEvent)
 
@@ -120,7 +110,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     assertTrue(eventSearchVM.uiState.value.id == "")
   }
@@ -136,7 +126,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventCreationVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     val eventID = eventCreationVM.uiState.value.id
 
@@ -149,7 +139,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     assertTrue(eventSearchVM.uiState.value.id == eventID)
 
@@ -161,7 +151,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     val eventSearch2VM =
         EventViewModel(
@@ -172,14 +162,14 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearch2VM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     assertEqualEventVMWithEvent(eventSearch2VM, testUpdateEvent)
 
     eventSearch2VM.deleteTheEvent(
         onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearch2VM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
   }
 
   @Test
@@ -193,7 +183,7 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventCreationVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     val eventID = eventCreationVM.uiState.value.id
 
@@ -206,24 +196,24 @@ class EventViewModelTests {
 
     // Wait for database to get the data
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     assertTrue(eventSearchVM.uiState.value.guests.isEmpty())
 
-    changeAccount(TEST_ACCOUNTS[0])
+    database.accountManager.signInTo(TEST_ACCOUNTS[0])
     eventSearchVM.joinTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
-    changeAccount(TEST_ACCOUNTS[1])
+    database.accountManager.signInTo(TEST_ACCOUNTS[1])
     eventSearchVM.joinTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
-    changeAccount(TEST_ACCOUNTS[2])
+    database.accountManager.signInTo(TEST_ACCOUNTS[2])
     eventSearchVM.joinTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     assertTrue(eventSearchVM.uiState.value.guests.size == 3)
     assertTrue(
@@ -236,23 +226,23 @@ class EventViewModelTests {
 
     eventSearchVM.leaveTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
-    changeAccount(TEST_ACCOUNTS[1])
+    database.accountManager.signInTo(TEST_ACCOUNTS[1])
     eventSearchVM.leaveTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
-    changeAccount(TEST_ACCOUNTS[0])
+    database.accountManager.signInTo(TEST_ACCOUNTS[0])
     eventSearchVM.leaveTheEvent(onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     assertTrue(eventSearchVM.uiState.value.guests.isEmpty())
 
     eventSearchVM.deleteTheEvent(
         onSuccess = { assertTrue(true) }, onFailure = { assertTrue(false) })
     while (eventSearchVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
   }
 }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/MyEventsViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/MyEventsViewModelTests.kt
@@ -1,14 +1,12 @@
 package com.monkeyteam.chimpagne.newtests.viewmodels
 
 import com.monkeyteam.chimpagne.model.database.Database
-import com.monkeyteam.chimpagne.newtests.DELAY_AMOUNT_MILLIS
+import com.monkeyteam.chimpagne.newtests.SLEEP_AMOUNT_MILLIS
 import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
 import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
 import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
 import com.monkeyteam.chimpagne.viewmodels.MyEventsViewModel
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 
@@ -33,7 +31,7 @@ class MyEventsViewModelTests {
     val eventVM = MyEventsViewModel(database, { assertTrue(true) }, { assertTrue(false) })
 
     while (eventVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     assertTrue(eventVM.uiState.value.createdEvents.size == 1)
     assertTrue(
@@ -52,7 +50,7 @@ class MyEventsViewModelTests {
     val eventVM = MyEventsViewModel(database, { assertTrue(true) }, { assertTrue(false) })
 
     while (eventVM.uiState.value.loading) {}
-    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
 
     assertTrue(eventVM.uiState.value.createdEvents.isEmpty())
     assertTrue(eventVM.uiState.value.joinedEvents.isEmpty())

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/MyEventsViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/MyEventsViewModelTests.kt
@@ -1,23 +1,25 @@
 package com.monkeyteam.chimpagne.newtests.viewmodels
 
 import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.newtests.DELAY_AMOUNT_MILLIS
 import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
 import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
 import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
-import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
 import com.monkeyteam.chimpagne.viewmodels.MyEventsViewModel
 import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 
 class MyEventsViewModelTests {
   val database = Database()
 
-  val testAccount1 = TEST_ACCOUNTS[0] /*account with create and join event*/
-  val testAccount2 = TEST_ACCOUNTS[1] /*account with no create and no join event*/
+  private val testAccount1 = TEST_ACCOUNTS[0] /*account with create and join event*/
+  private val testAccount2 = TEST_ACCOUNTS[1] /*account with no create and no join event*/
 
-  val joinedEventForAccount1 = TEST_EVENTS[2]
-  val createdEventForAccount1 = TEST_EVENTS[3]
+  private val joinedEventForAccount1 = TEST_EVENTS[2]
+  private val createdEventForAccount1 = TEST_EVENTS[3]
 
   @Before
   fun initTests() {
@@ -26,15 +28,12 @@ class MyEventsViewModelTests {
 
   @Test
   fun fetchingGuestEventsWithCreatedAndJoinedEvents() {
-    val accountViewModel = AccountViewModel(database = database)
-
-    accountViewModel.loginToChimpagneAccount(testAccount1.firebaseAuthUID, {}, {})
-
-    while (accountViewModel.uiState.value.loading) {}
+    database.accountManager.signInTo(testAccount1)
 
     val eventVM = MyEventsViewModel(database, { assertTrue(true) }, { assertTrue(false) })
 
     while (eventVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     assertTrue(eventVM.uiState.value.createdEvents.size == 1)
     assertTrue(
@@ -48,15 +47,12 @@ class MyEventsViewModelTests {
 
   @Test
   fun fetchingGuestEventsWithNoEvents() {
-    val accountViewModel = AccountViewModel(database = database)
-
-    accountViewModel.loginToChimpagneAccount(testAccount2.firebaseAuthUID, {}, {})
-
-    while (accountViewModel.uiState.value.loading) {}
+    database.accountManager.signInTo(testAccount2)
 
     val eventVM = MyEventsViewModel(database, { assertTrue(true) }, { assertTrue(false) })
 
     while (eventVM.uiState.value.loading) {}
+    runBlocking { delay(DELAY_AMOUNT_MILLIS) }
 
     assertTrue(eventVM.uiState.value.createdEvents.isEmpty())
     assertTrue(eventVM.uiState.value.joinedEvents.isEmpty())


### PR DESCRIPTION
This PR is meant to fix issue #157: 
Where doing multiple firebase requests sometimes don't work making some tests fail.
To fix this I added delays to separate each requests so that they can be done correctly.
I also fixed some other inconsistencies with the view model tests such as the way you log into an account. 