### PR TITLE
AccountViewModel.fetchAccounts

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/AccountViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/AccountViewModelTests.kt
@@ -94,4 +94,15 @@ class AccountViewModelTests {
     val accountViewModel = AccountViewModel(database = database)
     assertFalse(accountViewModel.isUserLoggedIn())
   }
+
+  @Test
+  fun fetchAccountsTest() {
+    val accounts = TEST_ACCOUNTS.associate { (it.firebaseAuthUID to it) }
+
+    val accountViewModel = AccountViewModel(database = database)
+    accountViewModel.fetchAccounts(accounts.keys.toList())
+    while (accountViewModel.uiState.value.loading) {}
+
+    assertEquals(accounts, accountViewModel.uiState.value.fetchedAccounts)
+  }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/AccountViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/AccountViewModel.kt
@@ -129,11 +129,10 @@ class AccountViewModel(database: Database) : ViewModel() {
 
   fun fetchAccounts(accountUIDs: List<ChimpagneAccountUID>) {
     _uiState.value = _uiState.value.copy(loading = true)
-    accountManager.getAccounts(accountUIDs, {
-      _uiState.value = _uiState.value.copy(fetchedAccounts = it, loading = false)
-    }, {
-      _uiState.value = _uiState.value.copy(loading = false)
-    })
+    accountManager.getAccounts(
+        accountUIDs,
+        { _uiState.value = _uiState.value.copy(fetchedAccounts = it, loading = false) },
+        { _uiState.value = _uiState.value.copy(loading = false) })
   }
 }
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/AccountViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/AccountViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.monkeyteam.chimpagne.model.database.ChimpagneAccount
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
 import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.model.location.Location
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -125,6 +126,15 @@ class AccountViewModel(database: Database) : ViewModel() {
   fun isUserLoggedIn(): Boolean {
     return FirebaseAuth.getInstance().currentUser != null
   }
+
+  fun fetchAccounts(accountUIDs: List<ChimpagneAccountUID>) {
+    _uiState.value = _uiState.value.copy(loading = true)
+    accountManager.getAccounts(accountUIDs, {
+      _uiState.value = _uiState.value.copy(fetchedAccounts = it, loading = false)
+    }, {
+      _uiState.value = _uiState.value.copy(loading = false)
+    })
+  }
 }
 
 /**
@@ -138,6 +148,7 @@ data class AccountUIState(
     val tempAccount: ChimpagneAccount = ChimpagneAccount(),
     val currentUserProfilePicture: Uri? = null,
     val tempProfilePicture: Uri? = null,
+    val fetchedAccounts: Map<ChimpagneAccountUID, ChimpagneAccount?> = hashMapOf(),
     val loading: Boolean = false
 )
 


### PR DESCRIPTION
This PR adds the method `fetchAccounts` the AccountViewModel. It takes a list of `ChimpagneAccountUID` as parameter and stores the result of the request in `uiStage.value.fetchedAccounts` as a `Map<ChimpagneAccountUID, ChimpagneAccount>`. Use this method in the NavGraph of MainActivity when the UID of a `ChimpagneAccount` isn't sufficient for your screen.