### PR TITLE
Navgraph fix

### DIFF
--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/AccountCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/AccountCreationScreen.kt
@@ -56,11 +56,11 @@ fun AccountCreation(navObject: NavigationActions, accountViewModel: AccountViewM
           navObject.navigateTo(Route.LOADING)
           accountViewModel.submitUpdatedAccount(
               onSuccess = {
-                navObject.navigateTo(Route.HOME_SCREEN)
+                navObject.clearAndNavigateTo(Route.HOME_SCREEN, true)
                 Toast.makeText(context, "Account created", Toast.LENGTH_SHORT).show()
               },
               onFailure = {
-                navObject.navigateTo(Route.LOGIN_SCREEN)
+                navObject.clearAndNavigateTo(Route.LOGIN_SCREEN, true)
                 Toast.makeText(context, "Failed to create account", Toast.LENGTH_SHORT).show()
               })
         } else {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/navigation/NavigationActions.kt
@@ -1,6 +1,5 @@
 package com.monkeyteam.chimpagne.ui.navigation
 
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 
 object Route {
@@ -25,13 +24,13 @@ class NavigationActions(private val navController: NavHostController) {
       // avoid building up a large stack of destinations
       // on the back stack as users select items
 
-//      popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+      //      popUpTo(navController.graph.findStartDestination().id) { saveState = true }
 
       // Avoid multiple copies of the same destination when
       // reselecting the same item
       launchSingleTop = true
       // Restore state when reselecting a previously selected item
-//      restoreState = true
+      //      restoreState = true
     }
   }
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/navigation/NavigationActions.kt
@@ -24,12 +24,14 @@ class NavigationActions(private val navController: NavHostController) {
       // Pop up to the start destination of the graph to
       // avoid building up a large stack of destinations
       // on the back stack as users select items
-      popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+
+//      popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+
       // Avoid multiple copies of the same destination when
       // reselecting the same item
       launchSingleTop = true
       // Restore state when reselecting a previously selected item
-      restoreState = true
+//      restoreState = true
     }
   }
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/navigation/NavigationActions.kt
@@ -20,17 +20,9 @@ object Route {
 class NavigationActions(private val navController: NavHostController) {
   fun navigateTo(route: String) {
     navController.navigate(route) {
-      // Pop up to the start destination of the graph to
-      // avoid building up a large stack of destinations
-      // on the back stack as users select items
-
-      //      popUpTo(navController.graph.findStartDestination().id) { saveState = true }
-
       // Avoid multiple copies of the same destination when
       // reselecting the same item
       launchSingleTop = true
-      // Restore state when reselecting a previously selected item
-      //      restoreState = true
     }
   }
 


### PR DESCRIPTION
This PR finally fixes our NavGraph ! Now it *really* goes back to the previous screen. The issue was in the `navigateTo` method of `NavigationActions`. Also when you have finished your account creation, you cannot go back to the AccountCreationScreen.