### PR TITLE
Leave event on event deletion

### DIFF
--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/AtomicChimpagneAccountManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/AtomicChimpagneAccountManager.kt
@@ -1,0 +1,20 @@
+package com.monkeyteam.chimpagne.model.database
+
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.storage.StorageReference
+
+class AtomicChimpagneAccountManager(
+    private val database: Database,
+    private val accounts: CollectionReference,
+    private val profilePictures: StorageReference
+) {
+  fun leaveEvent(
+      uid: ChimpagneAccountUID,
+      eventId: ChimpagneEventId,
+      onSuccess: () -> Unit,
+      onFailure: () -> Unit
+  ) {
+    accounts.document(uid).update("joinedEvent.$eventId", FieldValue.delete())
+  }
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
@@ -17,6 +17,8 @@ class ChimpagneAccountManager(
     private val profilePictures: StorageReference
 ) {
 
+  val atomic = AtomicChimpagneAccountManager(database, accounts, profilePictures)
+
   /**
    * This field stores the current logged user's account, you can retrieve it from any class using
    *


### PR DESCRIPTION
This PR just fixes issue #164: when an event is deleted, the event reference is removed from the `joinedEvent` field of all the entries in the "accounts" table so we don't have any "ghost" events.