### PR TITLE
Fixed inconsistencies in Create and Edit Event

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EditEventScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EditEventScreenTest.kt
@@ -45,7 +45,7 @@ class ButtonToastTest {
       EditEventScreen(2, navActions, viewModel(factory = EventViewModelFactory(null, database)))
     }
 
-    composeTestRule.onNodeWithTag("save_changes_button").performClick()
+    composeTestRule.onNodeWithTag("last_button").performClick()
     //  toasts are not composable in nature, which makes them difficult to test within the Jetpack
     // Compose framework.
   }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EditEventScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EditEventScreenTest.kt
@@ -3,6 +3,7 @@ package com.monkeyteam.chimpagne.newtests.ui.event
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -178,8 +179,8 @@ class EditEventScreenTestTest {
       val navActions = NavigationActions(navController)
       EditEventScreen(4, navActions, viewModel(factory = EventViewModelFactory(null, database)))
     }
-    composeTestRule.onNodeWithTag("logistics_title").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("parking_title").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("beds_title").assertIsDisplayed()
+    composeTestRule.onNodeWithContentDescription("logistics_title").assertIsDisplayed()
+    composeTestRule.onNodeWithContentDescription("parking_title").assertIsDisplayed()
+    composeTestRule.onNodeWithContentDescription("beds_title").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -143,15 +144,15 @@ class EventCreationScreenTest {
       EventCreationScreen(2, navActions, viewModel(factory = EventViewModelFactory(null, database)))
     }
     // composeTestRule.onNodeWithTag("tag_field").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("groceries_title").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("add_groceries_button").assertIsDisplayed()
+    composeTestRule.onNodeWithContentDescription("supplies_title").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("add_supplies_button").assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag("add_groceries_button").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("add_groceries_button").performClick()
+    composeTestRule.onNodeWithTag("add_supplies_button").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("add_supplies_button").performClick()
     // Assert that the SupplyPopup is displayed after clicking the button
-    composeTestRule.onNodeWithTag("groceries_title").assertIsDisplayed()
+    composeTestRule.onNodeWithContentDescription("supplies_title").assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag("add_groceries_button").performClick()
+    composeTestRule.onNodeWithTag("add_supplies_button").performClick()
     // Fill in the necessary fields in the SupplyPopup
     composeTestRule.onNodeWithTag("supplies_description_field").performTextInput("New Item")
     composeTestRule.onNodeWithTag("supplies_quantity_field").performTextInput("5")
@@ -219,8 +220,8 @@ class EventCreationScreenTest {
       val navActions = NavigationActions(navController)
       EventCreationScreen(4, navActions, viewModel(factory = EventViewModelFactory(null, database)))
     }
-    composeTestRule.onNodeWithTag("logistics_title").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("parking_title").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("beds_title").assertIsDisplayed()
+    composeTestRule.onNodeWithContentDescription("logistics_title").assertIsDisplayed()
+    composeTestRule.onNodeWithContentDescription("parking_title").assertIsDisplayed()
+    composeTestRule.onNodeWithContentDescription("beds_title").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
@@ -60,13 +60,8 @@ class EventCreationScreenTest {
     // Move to the Second Panel
 
     composeTestRule.onNodeWithTag("next_button").performClick()
-    // composeTestRule.onNodeWithTag("next_button")
-    // composeTestRule.onNodeWithText("More event infos").assertIsDisplayed()
-
     // Return to the First Panel
     composeTestRule.onNodeWithTag("previous_button").performClick()
-
-    // composeTestRule.onNodeWithText("Title").assertIsDisplayed()
   }
 
   @Test
@@ -197,7 +192,7 @@ class EventCreationScreenTest {
 
     composeTestRule.onNodeWithTag("next_button").assertDoesNotExist()
 
-    composeTestRule.onNodeWithTag("create_event_button").performClick()
+    composeTestRule.onNodeWithTag("last_button").performClick()
   }
 
   @Test

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdvancedLogisticsPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdvancedLogisticsPanel.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Bed
+import androidx.compose.material.icons.rounded.DirectionsCar
+import androidx.compose.material.icons.rounded.Layers
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.ui.components.Legend
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 
 @Composable
@@ -30,15 +34,15 @@ fun AdvancedLogisticsPanel(eventViewModel: EventViewModel) {
   var parkingText by remember { mutableStateOf(uiState.parkingSpaces.toString()) }
   var bedsText by remember { mutableStateOf(uiState.beds.toString()) }
   Column(modifier = Modifier.padding(16.dp)) {
-    Text(
+    Legend(
         stringResource(id = R.string.event_creation_screen_logistics),
-        style = MaterialTheme.typography.headlineSmall,
-        modifier = Modifier.testTag("logistics_title"))
+        Icons.Rounded.Layers,
+        "logistics_title")
     Spacer(modifier = Modifier.height(16.dp))
-    Text(
+    Legend(
         stringResource(id = R.string.event_creation_screen_parking),
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.testTag("parking_title"))
+        Icons.Rounded.DirectionsCar,
+        "parking_title")
     OutlinedTextField(
         value = parkingText,
         onValueChange = {
@@ -54,10 +58,8 @@ fun AdvancedLogisticsPanel(eventViewModel: EventViewModel) {
         modifier = Modifier.fillMaxWidth().testTag("n_parking"))
 
     Spacer(modifier = Modifier.height(16.dp))
-    Text(
-        stringResource(id = R.string.event_creation_screen_beds),
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.testTag("beds_title"))
+    Legend(
+        stringResource(id = R.string.event_creation_screen_beds), Icons.Rounded.Bed, "beds_title")
     OutlinedTextField(
         value = bedsText,
         onValueChange = {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
@@ -3,32 +3,40 @@ package com.monkeyteam.chimpagne.ui.event
 import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
-import com.monkeyteam.chimpagne.ui.components.GoBackButton
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun EditEventScreen(
     initialPage: Int = 0,
@@ -36,72 +44,82 @@ fun EditEventScreen(
     eventViewModel: EventViewModel
 ) {
   val uiState by eventViewModel.uiState.collectAsState()
-
   val pagerState = rememberPagerState(initialPage = initialPage) { 3 }
   val coroutineScope = rememberCoroutineScope()
   val context = LocalContext.current
-  Column {
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
-      GoBackButton(navigationActions = navObject)
-      Text(text = stringResource(id = R.string.edit_event))
-    }
-    HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->
-      when (page) {
-        0 -> FirstPanel(eventViewModel)
-        1 -> TagsAndPubPanel(eventViewModel)
-        2 -> AdvancedLogisticsPanel(eventViewModel)
-      }
-    }
-
-    // The logic below is to make sure to display the proper panel navigation button
-    // throughout the panels
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-      if (pagerState.currentPage > 0) {
-        Button(
-            onClick = {
-              coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) }
-            },
-            modifier = Modifier.testTag("previous_button")) {
-              Text(stringResource(id = R.string.event_creation_screen_previous))
-            }
-      } else {
-        Spacer(modifier = Modifier.width(ButtonDefaults.MinWidth))
-      }
-      if (pagerState.currentPage < 2) {
-        Button(
-            onClick = {
-              coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
-            },
-            modifier = Modifier.testTag("next_button")) {
-              Text(stringResource(id = R.string.event_creation_screen_next))
-            }
-      } else {
-        Button(
-            onClick = {
-              if (!uiState.loading) {
-                eventViewModel.updateTheEvent(
-                    onSuccess = {
-                      Toast.makeText(
-                              context,
-                              context.getString(R.string.edit_event_toast_finish),
-                              Toast.LENGTH_SHORT)
-                          .show()
-                      navObject.goBack()
-                    },
-                    onFailure = {
-                      Toast.makeText(
-                              context,
-                              context.getString(R.string.edit_event_save_failure),
-                              Toast.LENGTH_SHORT)
-                          .show()
-                      navObject.goBack()
-                    })
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = { Text(stringResource(id = R.string.edit_event)) },
+            modifier = Modifier.shadow(4.dp),
+            navigationIcon = {
+              IconButton(onClick = { navObject.goBack() }) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
               }
-            },
-            modifier = Modifier.testTag("save_changes_button")) {
-              Text(stringResource(id = R.string.save_changes))
-            }
+            })
+      },
+      bottomBar = {
+        // The logic below is to make sure to display the proper panel navigation button
+        // throughout the panels
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+          if (pagerState.currentPage > 0) {
+            Button(
+                onClick = {
+                  coroutineScope.launch {
+                    pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                  }
+                },
+                modifier = Modifier.testTag("previous_button")) {
+                  Text(stringResource(id = R.string.event_creation_screen_previous))
+                }
+          } else {
+            Spacer(modifier = Modifier.width(ButtonDefaults.MinWidth))
+          }
+          if (pagerState.currentPage < 2) {
+            Button(
+                onClick = {
+                  coroutineScope.launch {
+                    pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                  }
+                },
+                modifier = Modifier.testTag("next_button")) {
+                  Text(stringResource(id = R.string.event_creation_screen_next))
+                }
+          } else {
+            Button(
+                onClick = {
+                  if (!uiState.loading) {
+                    eventViewModel.updateTheEvent(
+                        onSuccess = {
+                          Toast.makeText(
+                                  context,
+                                  context.getString(R.string.edit_event_toast_finish),
+                                  Toast.LENGTH_SHORT)
+                              .show()
+                          navObject.goBack()
+                        },
+                        onFailure = {
+                          Toast.makeText(
+                                  context,
+                                  context.getString(R.string.edit_event_save_failure),
+                                  Toast.LENGTH_SHORT)
+                              .show()
+                          navObject.goBack()
+                        })
+                  }
+                },
+                modifier = Modifier.testTag("save_changes_button")) {
+                  Text(stringResource(id = R.string.save_changes))
+                }
+          }
+        }
+      }) { innerPadding ->
+        HorizontalPager(state = pagerState, modifier = Modifier.padding(innerPadding)) { page ->
+          when (page) {
+            0 -> FirstPanel(eventViewModel)
+            1 -> TagsAndPubPanel(eventViewModel)
+            2 -> AdvancedLogisticsPanel(eventViewModel)
+          }
+        }
       }
-    }
-  }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
@@ -2,117 +2,67 @@ package com.monkeyteam.chimpagne.ui.event
 
 import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
-import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun EditEventScreen(
     initialPage: Int = 0,
     navObject: NavigationActions,
     eventViewModel: EventViewModel
 ) {
+  // This screen is made of several panels
+  // The user can go from panel either by swiping left and right,
+  // or by clicking the buttons on the bottom of the screen.
+
   val uiState by eventViewModel.uiState.collectAsState()
   val pagerState = rememberPagerState(initialPage = initialPage) { 3 }
-  val coroutineScope = rememberCoroutineScope()
   val context = LocalContext.current
   Scaffold(
       topBar = {
-        TopAppBar(
-            title = { Text(stringResource(id = R.string.edit_event)) },
-            modifier = Modifier.shadow(4.dp),
-            navigationIcon = {
-              IconButton(onClick = { navObject.goBack() }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-              }
-            })
+        PanelTopBar(
+            navObject = navObject,
+            title = stringResource(id = R.string.edit_event),
+            modifier = Modifier.testTag("edit_event_title"))
       },
       bottomBar = {
-        // The logic below is to make sure to display the proper panel navigation button
-        // throughout the panels
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-          if (pagerState.currentPage > 0) {
-            Button(
-                onClick = {
-                  coroutineScope.launch {
-                    pagerState.animateScrollToPage(pagerState.currentPage - 1)
-                  }
-                },
-                modifier = Modifier.testTag("previous_button")) {
-                  Text(stringResource(id = R.string.event_creation_screen_previous))
-                }
-          } else {
-            Spacer(modifier = Modifier.width(ButtonDefaults.MinWidth))
-          }
-          if (pagerState.currentPage < 2) {
-            Button(
-                onClick = {
-                  coroutineScope.launch {
-                    pagerState.animateScrollToPage(pagerState.currentPage + 1)
-                  }
-                },
-                modifier = Modifier.testTag("next_button")) {
-                  Text(stringResource(id = R.string.event_creation_screen_next))
-                }
-          } else {
-            Button(
-                onClick = {
-                  if (!uiState.loading) {
-                    eventViewModel.updateTheEvent(
-                        onSuccess = {
-                          Toast.makeText(
-                                  context,
-                                  context.getString(R.string.edit_event_toast_finish),
-                                  Toast.LENGTH_SHORT)
-                              .show()
-                          navObject.goBack()
-                        },
-                        onFailure = {
-                          Toast.makeText(
-                                  context,
-                                  context.getString(R.string.edit_event_save_failure),
-                                  Toast.LENGTH_SHORT)
-                              .show()
-                          navObject.goBack()
-                        })
-                  }
-                },
-                modifier = Modifier.testTag("save_changes_button")) {
-                  Text(stringResource(id = R.string.save_changes))
-                }
-          }
-        }
+        PanelBottomBar(
+            pagerState = pagerState,
+            lastButtonText = stringResource(id = R.string.save_changes),
+            lastButtonOnClick = {
+              if (!uiState.loading) {
+                eventViewModel.updateTheEvent(
+                    onSuccess = {
+                      Toast.makeText(
+                              context,
+                              context.getString(R.string.edit_event_toast_finish),
+                              Toast.LENGTH_SHORT)
+                          .show()
+                      navObject.goBack()
+                    },
+                    onFailure = {
+                      Toast.makeText(
+                              context,
+                              context.getString(R.string.edit_event_save_failure),
+                              Toast.LENGTH_SHORT)
+                          .show()
+                      navObject.goBack()
+                    })
+              }
+            })
       }) { innerPadding ->
         HorizontalPager(state = pagerState, modifier = Modifier.padding(innerPadding)) { page ->
           when (page) {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -3,32 +3,40 @@ package com.monkeyteam.chimpagne.ui.event
 import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
-import com.monkeyteam.chimpagne.ui.components.GoBackButton
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun EventCreationScreen(
     initialPage: Int = 0,
@@ -44,66 +52,77 @@ fun EventCreationScreen(
   val pagerState = rememberPagerState(initialPage = initialPage) { 4 }
   val coroutineScope = rememberCoroutineScope()
   val context = LocalContext.current
-  Column {
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
-      GoBackButton(navigationActions = navObject)
-      Text(text = stringResource(id = R.string.event_creation_screen_name))
-    }
-    HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->
-      when (page) {
-        0 -> FirstPanel(eventViewModel)
-        1 -> TagsAndPubPanel(eventViewModel)
-        2 -> SuppliesPanel(eventViewModel)
-        3 -> AdvancedLogisticsPanel(eventViewModel)
-      }
-    }
-
-    // The logic below is to make sure to display the proper panel navigation button
-    // throughout the panels
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-      if (pagerState.currentPage > 0) {
-        Button(
-            onClick = {
-              coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) }
-            },
-            modifier = Modifier.testTag("previous_button")) {
-              Text(stringResource(id = R.string.event_creation_screen_previous))
-            }
-      } else {
-        Spacer(modifier = Modifier.width(ButtonDefaults.MinWidth))
-      }
-      if (pagerState.currentPage < 3) {
-        Button(
-            onClick = {
-              coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
-            },
-            modifier = Modifier.testTag("next_button")) {
-              Text(stringResource(id = R.string.event_creation_screen_next))
-            }
-      } else {
-        Button(
-            onClick = {
-              if (!uiState.loading) {
-                Toast.makeText(
-                        context,
-                        context.getString(R.string.event_creation_screen_toast_creating),
-                        Toast.LENGTH_SHORT)
-                    .show()
-                eventViewModel.createTheEvent(
-                    onSuccess = {
-                      Toast.makeText(
-                              context,
-                              context.getString(R.string.event_creation_screen_toast_finish),
-                              Toast.LENGTH_SHORT)
-                          .show()
-                      navObject.goBack()
-                    })
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = { Text(stringResource(id = R.string.event_creation_screen_name)) },
+            modifier = Modifier.shadow(4.dp),
+            navigationIcon = {
+              IconButton(onClick = { navObject.goBack() }) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
               }
-            },
-            modifier = Modifier.testTag("create_event_button")) {
-              Text(stringResource(id = R.string.event_creation_screen_create_event))
-            }
+            })
+      },
+      bottomBar = {
+        // The logic below is to make sure to display the proper panel navigation button
+        // throughout the panels
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+          if (pagerState.currentPage > 0) {
+            Button(
+                onClick = {
+                  coroutineScope.launch {
+                    pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                  }
+                },
+                modifier = Modifier.testTag("previous_button")) {
+                  Text(stringResource(id = R.string.event_creation_screen_previous))
+                }
+          } else {
+            Spacer(modifier = Modifier.width(ButtonDefaults.MinWidth))
+          }
+          if (pagerState.currentPage < 3) {
+            Button(
+                onClick = {
+                  coroutineScope.launch {
+                    pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                  }
+                },
+                modifier = Modifier.testTag("next_button")) {
+                  Text(stringResource(id = R.string.event_creation_screen_next))
+                }
+          } else {
+            Button(
+                onClick = {
+                  if (!uiState.loading) {
+                    Toast.makeText(
+                            context,
+                            context.getString(R.string.event_creation_screen_toast_creating),
+                            Toast.LENGTH_SHORT)
+                        .show()
+                    eventViewModel.createTheEvent(
+                        onSuccess = {
+                          Toast.makeText(
+                                  context,
+                                  context.getString(R.string.event_creation_screen_toast_finish),
+                                  Toast.LENGTH_SHORT)
+                              .show()
+                          navObject.goBack()
+                        })
+                  }
+                },
+                modifier = Modifier.testTag("create_event_button")) {
+                  Text(stringResource(id = R.string.event_creation_screen_create_event))
+                }
+          }
+        }
+      }) { innerPadding ->
+        HorizontalPager(state = pagerState, modifier = Modifier.padding(innerPadding)) { page ->
+          when (page) {
+            0 -> FirstPanel(eventViewModel)
+            1 -> TagsAndPubPanel(eventViewModel)
+            2 -> SuppliesPanel(eventViewModel)
+            3 -> AdvancedLogisticsPanel(eventViewModel)
+          }
+        }
       }
-    }
-  }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -2,41 +2,22 @@ package com.monkeyteam.chimpagne.ui.event
 
 import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
-import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun EventCreationScreen(
     initialPage: Int = 0,
@@ -47,74 +28,38 @@ fun EventCreationScreen(
   // The user can go from panel either by swiping left and right,
   // or by clicking the buttons on the bottom of the screen.
 
-  val uiState by eventViewModel.uiState.collectAsState()
-
   val pagerState = rememberPagerState(initialPage = initialPage) { 4 }
-  val coroutineScope = rememberCoroutineScope()
   val context = LocalContext.current
+  val uiState by eventViewModel.uiState.collectAsState()
   Scaffold(
       topBar = {
-        TopAppBar(
-            title = { Text(stringResource(id = R.string.event_creation_screen_name)) },
-            modifier = Modifier.shadow(4.dp),
-            navigationIcon = {
-              IconButton(onClick = { navObject.goBack() }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-              }
-            })
+        PanelTopBar(
+            navObject = navObject,
+            title = stringResource(id = R.string.event_creation_screen_name),
+            modifier = Modifier.testTag("create_event_title"))
       },
       bottomBar = {
-        // The logic below is to make sure to display the proper panel navigation button
-        // throughout the panels
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-          if (pagerState.currentPage > 0) {
-            Button(
-                onClick = {
-                  coroutineScope.launch {
-                    pagerState.animateScrollToPage(pagerState.currentPage - 1)
-                  }
-                },
-                modifier = Modifier.testTag("previous_button")) {
-                  Text(stringResource(id = R.string.event_creation_screen_previous))
-                }
-          } else {
-            Spacer(modifier = Modifier.width(ButtonDefaults.MinWidth))
-          }
-          if (pagerState.currentPage < 3) {
-            Button(
-                onClick = {
-                  coroutineScope.launch {
-                    pagerState.animateScrollToPage(pagerState.currentPage + 1)
-                  }
-                },
-                modifier = Modifier.testTag("next_button")) {
-                  Text(stringResource(id = R.string.event_creation_screen_next))
-                }
-          } else {
-            Button(
-                onClick = {
-                  if (!uiState.loading) {
-                    Toast.makeText(
-                            context,
-                            context.getString(R.string.event_creation_screen_toast_creating),
-                            Toast.LENGTH_SHORT)
-                        .show()
-                    eventViewModel.createTheEvent(
-                        onSuccess = {
-                          Toast.makeText(
-                                  context,
-                                  context.getString(R.string.event_creation_screen_toast_finish),
-                                  Toast.LENGTH_SHORT)
-                              .show()
-                          navObject.goBack()
-                        })
-                  }
-                },
-                modifier = Modifier.testTag("create_event_button")) {
-                  Text(stringResource(id = R.string.event_creation_screen_create_event))
-                }
-          }
-        }
+        PanelBottomBar(
+            pagerState = pagerState,
+            lastButtonText = stringResource(id = R.string.event_creation_screen_create_event),
+            lastButtonOnClick = {
+              if (!uiState.loading) {
+                Toast.makeText(
+                        context,
+                        context.getString(R.string.event_creation_screen_toast_creating),
+                        Toast.LENGTH_SHORT)
+                    .show()
+                eventViewModel.createTheEvent(
+                    onSuccess = {
+                      Toast.makeText(
+                              context,
+                              context.getString(R.string.event_creation_screen_toast_finish),
+                              Toast.LENGTH_SHORT)
+                          .show()
+                      navObject.goBack()
+                    })
+              }
+            })
       }) { innerPadding ->
         HorizontalPager(state = pagerState, modifier = Modifier.padding(innerPadding)) { page ->
           when (page) {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/FirstPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/FirstPanel.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CalendarToday
 import androidx.compose.material.icons.rounded.Description
@@ -32,72 +33,76 @@ import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 fun FirstPanel(eventViewModel: EventViewModel) {
   val uiState by eventViewModel.uiState.collectAsState()
 
-  Column(modifier = Modifier.padding(16.dp)) {
-    Legend(
-        stringResource(id = R.string.event_creation_screen_title_legend),
-        Icons.Rounded.Title,
-        "Title")
-    Spacer(Modifier.height(16.dp))
-    OutlinedTextField(
-        value = uiState.title,
-        onValueChange = eventViewModel::updateEventTitle,
-        label = { Text(stringResource(id = R.string.event_creation_screen_title)) },
-        modifier = Modifier.fillMaxWidth().testTag("add_a_title"))
+  LazyColumn(horizontalAlignment = Alignment.Start) {
+    item {
+      Column(modifier = Modifier.padding(16.dp)) {
+        Legend(
+            stringResource(id = R.string.event_creation_screen_title_legend),
+            Icons.Rounded.Title,
+            "Title")
+        Spacer(Modifier.height(16.dp))
+        OutlinedTextField(
+            value = uiState.title,
+            onValueChange = eventViewModel::updateEventTitle,
+            label = { Text(stringResource(id = R.string.event_creation_screen_title)) },
+            modifier = Modifier.fillMaxWidth().testTag("add_a_title"))
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    Legend(
-        stringResource(id = R.string.event_creation_screen_description_legend),
-        Icons.Rounded.Description,
-        "Description")
+        Legend(
+            stringResource(id = R.string.event_creation_screen_description_legend),
+            Icons.Rounded.Description,
+            "Description")
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    OutlinedTextField(
-        value = uiState.description,
-        onValueChange = eventViewModel::updateEventDescription,
-        label = { Text(stringResource(id = R.string.event_creation_screen_description)) },
-        modifier = Modifier.fillMaxWidth().testTag("add_a_description"),
-        maxLines = 3)
-    Spacer(modifier = Modifier.height(16.dp))
+        OutlinedTextField(
+            value = uiState.description,
+            onValueChange = eventViewModel::updateEventDescription,
+            label = { Text(stringResource(id = R.string.event_creation_screen_description)) },
+            modifier = Modifier.fillMaxWidth().testTag("add_a_description"),
+            maxLines = 3)
+        Spacer(modifier = Modifier.height(16.dp))
 
-    Legend(
-        stringResource(id = R.string.event_creation_screen_location_legend),
-        Icons.Rounded.LocationOn,
-        "Location")
+        Legend(
+            stringResource(id = R.string.event_creation_screen_location_legend),
+            Icons.Rounded.LocationOn,
+            "Location")
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    LocationSelector(uiState.location, eventViewModel::updateEventLocation)
+        LocationSelector(uiState.location, eventViewModel::updateEventLocation)
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    Legend(
-        stringResource(id = R.string.event_creation_screen_start_date_legend),
-        Icons.Rounded.CalendarToday,
-        "Start Date")
+        Legend(
+            stringResource(id = R.string.event_creation_screen_start_date_legend),
+            Icons.Rounded.CalendarToday,
+            "Start Date")
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    DateSelector(
-        selectedDate = uiState.startsAtCalendarDate,
-        onDateSelected = eventViewModel::updateEventStartCalendarDate,
-        modifier = Modifier.align(Alignment.CenterHorizontally),
-        selectTimeOfDay = true)
+        DateSelector(
+            selectedDate = uiState.startsAtCalendarDate,
+            onDateSelected = eventViewModel::updateEventStartCalendarDate,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            selectTimeOfDay = true)
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    Legend(
-        stringResource(id = R.string.event_creation_screen_end_date_legend),
-        Icons.Rounded.CalendarToday,
-        "End Date")
+        Legend(
+            stringResource(id = R.string.event_creation_screen_end_date_legend),
+            Icons.Rounded.CalendarToday,
+            "End Date")
 
-    Spacer(modifier = Modifier.height(16.dp))
-    // We will need to add some tests for DateSelector also
-    DateSelector(
-        selectedDate = uiState.endsAtCalendarDate,
-        onDateSelected = eventViewModel::updateEventEndCalendarDate,
-        modifier = Modifier.align(Alignment.CenterHorizontally),
-        selectTimeOfDay = true)
+        Spacer(modifier = Modifier.height(16.dp))
+        // We will need to add some tests for DateSelector also
+        DateSelector(
+            selectedDate = uiState.endsAtCalendarDate,
+            onDateSelected = eventViewModel::updateEventEndCalendarDate,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            selectTimeOfDay = true)
+      }
+    }
   }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/PanelBars.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/PanelBars.kt
@@ -1,0 +1,81 @@
+package com.monkeyteam.chimpagne.ui.event
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PanelTopBar(navObject: NavigationActions, title: String, modifier: Modifier = Modifier) {
+  TopAppBar(
+      title = { Text(title) },
+      modifier = modifier.shadow(4.dp),
+      navigationIcon = {
+        IconButton(onClick = { navObject.goBack() }) {
+          Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
+        }
+      })
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun PanelBottomBar(
+    pagerState: PagerState,
+    lastButtonText: String,
+    lastButtonOnClick: () -> Unit,
+) {
+  // The logic below is to make sure to display the proper panel navigation button
+  // throughout the panels
+  val coroutineScope = rememberCoroutineScope()
+
+  Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+    if (pagerState.currentPage > 0) {
+      Button(
+          onClick = {
+            coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) }
+          },
+          modifier = Modifier.testTag("previous_button")) {
+            Text(stringResource(id = R.string.event_creation_screen_previous))
+          }
+    } else {
+      Spacer(modifier = Modifier.width(ButtonDefaults.MinWidth))
+    }
+    if (pagerState.currentPage < pagerState.pageCount - 1) {
+      Button(
+          onClick = {
+            coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
+          },
+          modifier = Modifier.testTag("next_button")) {
+            Text(stringResource(id = R.string.event_creation_screen_next))
+          }
+    } else {
+      Button(onClick = lastButtonOnClick, modifier = Modifier.testTag("last_button")) {
+        Text(lastButtonText)
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/SuppliesPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/SuppliesPanel.kt
@@ -8,11 +8,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.rounded.Inventory2
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButtonDefaults.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,6 +26,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.ui.components.Legend
 import com.monkeyteam.chimpagne.ui.components.SupplyPopup
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 
@@ -35,17 +36,17 @@ fun SuppliesPanel(eventViewModel: EventViewModel) {
   val uiState by eventViewModel.uiState.collectAsState()
 
   Column(modifier = Modifier.padding(16.dp)) {
-    Text(
-        stringResource(id = R.string.event_creation_screen_groceries),
-        style = MaterialTheme.typography.headlineSmall,
-        modifier = Modifier.testTag("groceries_title"))
+    Legend(
+        stringResource(id = R.string.event_creation_screen_supplies),
+        Icons.Rounded.Inventory2,
+        "supplies_title")
     Spacer(modifier = Modifier.height(16.dp))
 
     val showAddDialog = remember { mutableStateOf(false) }
     Button(
         onClick = { showAddDialog.value = true },
-        modifier = Modifier.testTag("add_groceries_button")) {
-          Text(stringResource(id = R.string.event_creation_screen_add_groceries))
+        modifier = Modifier.testTag("add_supplies_button")) {
+          Text(stringResource(id = R.string.event_creation_screen_add_supplies))
         }
 
     if (showAddDialog.value) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -27,9 +27,9 @@
     <string name="event_creation_screen_event_made_public">Cet événement a été rendu publique !</string>
     <string name="event_creation_screen_make_event_public">Rendre cet événement publique</string>
     <string name="event_creation_screen_public_legend">Visibilité De l\'événement</string>
-    <string name="event_creation_screen_groceries">Courses</string>
-    <string name="event_creation_screen_add_groceries">Ajouter des courses</string>
-    <string name="event_creation_screen_logistics">Logistique</string>
+    <string name="event_creation_screen_supplies">Courses</string>
+    <string name="event_creation_screen_add_supplies">Ajouter des courses</string>
+    <string name="event_creation_screen_logistics">Logistique avancée</string>
     <string name="event_creation_screen_parking">Parking</string>
     <string name="event_creation_screen_number_parking">Nombre de places de parque</string>
     <string name="event_creation_screen_number_beds">Nombre de lits</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="event_creation_screen_public_legend">Event Publicity</string>
     <string name="event_creation_screen_supplies">Supplies</string>
     <string name="event_creation_screen_add_supplies">Add supplies</string>
-    <string name="event_creation_screen_logistics">Advance Logistics</string>
+    <string name="event_creation_screen_logistics">Advanced Logistics</string>
     <string name="event_creation_screen_parking">Parking</string>
     <string name="event_creation_screen_number_parking">Number of parking places</string>
     <string name="event_creation_screen_number_beds">Number of beds</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,9 +27,9 @@
     <string name="event_creation_screen_event_made_public">This event has been made public !</string>
     <string name="event_creation_screen_make_event_public">Make this event public</string>
     <string name="event_creation_screen_public_legend">Event Publicity</string>
-    <string name="event_creation_screen_groceries">Supplies</string>
-    <string name="event_creation_screen_add_groceries">Add supplies</string>
-    <string name="event_creation_screen_logistics">Logistics</string>
+    <string name="event_creation_screen_supplies">Supplies</string>
+    <string name="event_creation_screen_add_supplies">Add supplies</string>
+    <string name="event_creation_screen_logistics">Advance Logistics</string>
     <string name="event_creation_screen_parking">Parking</string>
     <string name="event_creation_screen_number_parking">Number of parking places</string>
     <string name="event_creation_screen_number_beds">Number of beds</string>


### PR DESCRIPTION
This PR is meant to fix inconsistencies in the Create and Edit event screen:
 - Notably issue #166 where the top bars of both screens are misaligned and the text is small.
 - The first panel is now scrollable, which fixes the issue where the description can get so long that the lower buttons disappear and are no longer reachable.
 - All titles in panels now have icons and the text is of the same size to remain consistent with the first 2 panels.
 - All mentions of groceries have been swapped with supplies.
 - Panel's top and bottom bars are now in a separate file as they are a shared element for both screens, which removes some code duplication.