### PR TITLE
EventViewModel: add atomical supply methods

### DIFF
--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -343,6 +343,63 @@ class EventViewModel(
         })
   }
 
+  fun updateSupplyAtomically(supply: ChimpagneSupply) {
+    _uiState.value = _uiState.value.copy(loading = true)
+    eventManager.atomic.updateSupply(
+        _uiState.value.id,
+        supply,
+        {
+          _uiState.value =
+              _uiState.value.copy(
+                  supplies = _uiState.value.supplies + (supply.id to supply), loading = false)
+        },
+        {})
+  }
+
+  fun removeSupplyAtomically(supplyId: ChimpagneSupplyId) {
+    _uiState.value = _uiState.value.copy(loading = true)
+    eventManager.atomic.removeSupply(
+        _uiState.value.id,
+        supplyId,
+        {
+          _uiState.value =
+              _uiState.value.copy(supplies = _uiState.value.supplies - supplyId, loading = false)
+        },
+        {})
+  }
+
+  fun assignSupplyAtomically(supplyId: ChimpagneSupplyId, accountUID: ChimpagneAccountUID) {
+    _uiState.value = _uiState.value.copy(loading = true)
+    eventManager.atomic.assignSupply(
+        _uiState.value.id,
+        supplyId,
+        accountUID,
+        {
+          val supply = _uiState.value.supplies[supplyId] ?: return@assignSupply
+          val newSupply = supply.copy(assignedTo = supply.assignedTo + (accountUID to true))
+          _uiState.value =
+              _uiState.value.copy(
+                  supplies = _uiState.value.supplies + (supplyId to newSupply), loading = false)
+        },
+        {})
+  }
+
+  fun unassignSupplyAtomically(supplyId: ChimpagneSupplyId, accountUID: ChimpagneAccountUID) {
+    _uiState.value = _uiState.value.copy(loading = true)
+    eventManager.atomic.unassignSupply(
+        _uiState.value.id,
+        supplyId,
+        accountUID,
+        {
+          val supply = _uiState.value.supplies[supplyId] ?: return@unassignSupply
+          val newSupply = supply.copy(assignedTo = supply.assignedTo - accountUID)
+          _uiState.value =
+              _uiState.value.copy(
+                  supplies = _uiState.value.supplies + (supplyId to newSupply), loading = false)
+        },
+        {})
+  }
+
   data class EventUIState(
       val id: String = "",
       val title: String = "",


### PR DESCRIPTION
This PR adds atomic methods to update / remove and assign / unassign a supply to the EventViewModel. This will be useful for the Supply Screen (future PR). Those methods are "atomic" in the sense that they do not rewrite the entire event in the database. The changes are made "directly" and do not require a call to updateTheEvent() to take effect.