### PR TITLE
Supplies Screen

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/TestUtils.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/TestUtils.kt
@@ -75,7 +75,8 @@ val TEST_EVENTS =
             /* SAME AS EVENT 1 */
             startsAtTimestamp = buildTimestamp(9, 5, 2024, 15, 15),
             endsAtTimestamp = buildTimestamp(11, 5, 2024, 15, 15),
-            ownerId = "JUAN"),
+            ownerId = "JUAN",
+            supplies = mapOf("1" to ChimpagneSupply("1", "c", 1, "h"))),
         ChimpagneEvent(
             id = "LOTR",
             title = "Watch LOTR",

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/supplies/SuppliesScreenUITests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/supplies/SuppliesScreenUITests.kt
@@ -1,0 +1,92 @@
+package com.monkeyteam.chimpagne.newtests.ui.event.supplies
+
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildAt
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.newtests.SLEEP_AMOUNT_MILLIS
+import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
+import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
+import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
+import com.monkeyteam.chimpagne.ui.event.details.supplies.SuppliesScreen
+import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
+import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
+import com.monkeyteam.chimpagne.viewmodels.EventViewModel
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SuppliesScreenUITests {
+
+  val database = Database()
+
+  val ownerAccount = TEST_ACCOUNTS[1]
+  val event = TEST_EVENTS[0]
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun init() {
+    initializeTestDatabase()
+  }
+
+  @Test
+  fun staffViewTest() {
+    val eventViewModel = EventViewModel(event.id, database)
+    val accountViewModel = AccountViewModel(database)
+
+    var loading = true
+    accountViewModel.loginToChimpagneAccount(
+        ownerAccount.firebaseAuthUID, { loading = false }, { assertTrue(false) })
+    while (loading) {}
+
+    eventViewModel.fetchEvent(onSuccess = { accountViewModel.fetchAccounts(listOf(event.ownerId)) })
+
+    while (eventViewModel.uiState.value.loading && accountViewModel.uiState.value.loading) {}
+
+    var you = ""
+    composeTestRule.setContent {
+      you = stringResource(id = R.string.chimpagne_you)
+      val navController = rememberNavController()
+      val navActions = NavigationActions(navController)
+      SuppliesScreen(
+          navObject = navActions,
+          eventViewModel = eventViewModel,
+          accountViewModel = accountViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("edit_supply_dialog").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("guest_supply_dialog").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("staff_supply_dialog").assertDoesNotExist()
+
+    composeTestRule.onNodeWithTag("assigned_nobody").onChildAt(3).assertDoesNotExist()
+    composeTestRule.onNodeWithTag("supply_add").performClick()
+    composeTestRule.onNodeWithTag("supplies_add_button").performClick()
+    while (eventViewModel.uiState.value.loading) {}
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
+
+    composeTestRule.onNodeWithTag("assigned_nobody").onChildAt(3).performClick()
+    composeTestRule.onNodeWithTag("staff_supply_dialog").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithText(
+            "${ownerAccount.firstName} ${ownerAccount.lastName} ($you)", useUnmergedTree = true)
+        .performClick()
+    composeTestRule.onNodeWithTag("save_supply_button").performClick()
+    while (eventViewModel.uiState.value.loading) {}
+    Thread.sleep(SLEEP_AMOUNT_MILLIS)
+
+    composeTestRule.onNodeWithTag("assigned_you").onChildAt(0).assertIsDisplayed()
+  }
+
+  @Test fun guestViewTest() {}
+}

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/supplies/SupplyDialogsUITests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/supplies/SupplyDialogsUITests.kt
@@ -24,18 +24,18 @@ class SupplyDialogsUITests {
   @Test
   fun guestSupplyDialogAssignTest() {
     val assignedSupply =
-      ChimpagneSupply(
-        id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf("hector" to true))
+        ChimpagneSupply(
+            id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf("hector" to true))
     val unassignedSupply =
-      ChimpagneSupply(id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf())
+        ChimpagneSupply(id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf())
     var supply = unassignedSupply
     composeTestRule.setContent {
       GuestSupplyDialog(
-        supply,
-        { if (it) supply = assignedSupply else supply = unassignedSupply },
-        "hector",
-        hashMapOf("hector" to ChimpagneAccount("hector")),
-        onDismissRequest = {})
+          supply,
+          { if (it) supply = assignedSupply else supply = unassignedSupply },
+          "hector",
+          hashMapOf("hector" to ChimpagneAccount("hector")),
+          onDismissRequest = {})
     }
 
     composeTestRule.onNodeWithTag("guest_supply_dialog").isDisplayed()
@@ -47,18 +47,18 @@ class SupplyDialogsUITests {
   @Test
   fun guestSupplyDialogUnassignTest() {
     val assignedSupply =
-      ChimpagneSupply(
-        id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf("hector" to true))
+        ChimpagneSupply(
+            id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf("hector" to true))
     val unassignedSupply =
-      ChimpagneSupply(id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf())
+        ChimpagneSupply(id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf())
     var supply = assignedSupply
     composeTestRule.setContent {
       GuestSupplyDialog(
-        supply,
-        { if (it) supply = assignedSupply else supply = unassignedSupply },
-        "hector",
-        hashMapOf("hector" to ChimpagneAccount("hector")),
-        onDismissRequest = {})
+          supply,
+          { if (it) supply = assignedSupply else supply = unassignedSupply },
+          "hector",
+          hashMapOf("hector" to ChimpagneAccount("hector")),
+          onDismissRequest = {})
     }
 
     composeTestRule.onNodeWithTag("guest_supply_dialog").isDisplayed()
@@ -76,14 +76,14 @@ class SupplyDialogsUITests {
     var editButtonClicked = false
     composeTestRule.setContent {
       StaffSupplyDialog(
-        supply,
-        { editButtonClicked = true },
-        { deleteButtonClicked = true },
-        "hector",
-        hashMapOf(
-          "hector" to ChimpagneAccount("hector"),
-          "monkey" to ChimpagneAccount("monkey", "Monkey", "Prince")),
-        onDismissRequest = { dismissRequested = true })
+          supply,
+          { editButtonClicked = true },
+          { deleteButtonClicked = true },
+          "hector",
+          hashMapOf(
+              "hector" to ChimpagneAccount("hector"),
+              "monkey" to ChimpagneAccount("monkey", "Monkey", "Prince")),
+          onDismissRequest = { dismissRequested = true })
     }
 
     composeTestRule.onNodeWithText("Monkey Prince", useUnmergedTree = true).performClick()

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/supplies/SupplyDialogsUITests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/supplies/SupplyDialogsUITests.kt
@@ -1,0 +1,104 @@
+package com.monkeyteam.chimpagne.newtests.ui.event.supplies
+
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccount
+import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
+import com.monkeyteam.chimpagne.ui.event.details.supplies.GuestSupplyDialog
+import com.monkeyteam.chimpagne.ui.event.details.supplies.StaffSupplyDialog
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SupplyDialogsUITests {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun guestSupplyDialogAssignTest() {
+    val assignedSupply =
+      ChimpagneSupply(
+        id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf("hector" to true))
+    val unassignedSupply =
+      ChimpagneSupply(id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf())
+    var supply = unassignedSupply
+    composeTestRule.setContent {
+      GuestSupplyDialog(
+        supply,
+        { if (it) supply = assignedSupply else supply = unassignedSupply },
+        "hector",
+        hashMapOf("hector" to ChimpagneAccount("hector")),
+        onDismissRequest = {})
+    }
+
+    composeTestRule.onNodeWithTag("guest_supply_dialog").isDisplayed()
+    composeTestRule.onNodeWithTag("nobody_assigned").isDisplayed()
+    composeTestRule.onNodeWithTag("guest_supply_assign").performClick()
+    assertEquals(assignedSupply, supply)
+  }
+
+  @Test
+  fun guestSupplyDialogUnassignTest() {
+    val assignedSupply =
+      ChimpagneSupply(
+        id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf("hector" to true))
+    val unassignedSupply =
+      ChimpagneSupply(id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf())
+    var supply = assignedSupply
+    composeTestRule.setContent {
+      GuestSupplyDialog(
+        supply,
+        { if (it) supply = assignedSupply else supply = unassignedSupply },
+        "hector",
+        hashMapOf("hector" to ChimpagneAccount("hector")),
+        onDismissRequest = {})
+    }
+
+    composeTestRule.onNodeWithTag("guest_supply_dialog").isDisplayed()
+    composeTestRule.onNodeWithTag("nobody_assigned").isDisplayed()
+    composeTestRule.onNodeWithTag("guest_supply_unassign").performClick()
+    assertEquals(unassignedSupply, supply)
+  }
+
+  @Test
+  fun staffSupplyDialogTest() {
+    val supply = ChimpagneSupply(assignedTo = mapOf("hector" to true))
+
+    var dismissRequested = false
+    var deleteButtonClicked = false
+    var editButtonClicked = false
+    composeTestRule.setContent {
+      StaffSupplyDialog(
+        supply,
+        { editButtonClicked = true },
+        { deleteButtonClicked = true },
+        "hector",
+        hashMapOf(
+          "hector" to ChimpagneAccount("hector"),
+          "monkey" to ChimpagneAccount("monkey", "Monkey", "Prince")),
+        onDismissRequest = { dismissRequested = true })
+    }
+
+    composeTestRule.onNodeWithText("Monkey Prince", useUnmergedTree = true).performClick()
+
+    composeTestRule.onNodeWithTag("cancel_supply_button").performClick()
+    assertTrue(dismissRequested)
+
+    composeTestRule.onNodeWithTag("delete_supply_button").performClick()
+    composeTestRule.onNodeWithTag("cancel_delete_button").isDisplayed()
+    composeTestRule.onNodeWithTag("confirm_delete_button").performClick()
+    assertTrue(deleteButtonClicked)
+
+    composeTestRule.onNodeWithTag("edit_supply_button").performClick()
+    composeTestRule.onNodeWithTag("supplies_add_button").performClick()
+    composeTestRule.onNodeWithTag("save_supply_button").performClick()
+    assertTrue(editButtonClicked)
+  }
+}

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/supplies/SupplyScreenComponentsUITests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/supplies/SupplyScreenComponentsUITests.kt
@@ -1,0 +1,45 @@
+package com.monkeyteam.chimpagne.newtests.ui.event.supplies
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
+import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
+import com.monkeyteam.chimpagne.ui.event.details.supplies.SupplyCard
+import com.monkeyteam.chimpagne.ui.event.details.supplies.SupplyDialogAccountEntry
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SupplyScreenComponentsUITests {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private val supply =
+    ChimpagneSupply(
+      id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf("hector" to true))
+
+  @Test
+  fun supplyCardTest() {
+    composeTestRule.setContent { SupplyCard(supply = supply) {} }
+    composeTestRule.onNodeWithTag("supply_quantity_and_unit", useUnmergedTree = true).assertExists()
+    composeTestRule.onNodeWithTag("supply_nb_assigned", useUnmergedTree = true).assertExists()
+  }
+
+  @Test
+  fun supplyAccountEntryTest() {
+    composeTestRule.setContent {
+      SupplyDialogAccountEntry(
+        account = TEST_ACCOUNTS[0],
+        loggedUserUID = TEST_ACCOUNTS[0].firebaseAuthUID,
+        showCheckBox = true)
+    }
+
+    composeTestRule
+      .onNodeWithTag("supply_account_entry", useUnmergedTree = true)
+      .assertHasClickAction()
+    composeTestRule.onNodeWithTag("supply_account_checkbox", useUnmergedTree = true).assertExists()
+  }
+}

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/supplies/SupplyScreenComponentsUITests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/supplies/SupplyScreenComponentsUITests.kt
@@ -18,8 +18,8 @@ class SupplyScreenComponentsUITests {
   @get:Rule val composeTestRule = createComposeRule()
 
   private val supply =
-    ChimpagneSupply(
-      id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf("hector" to true))
+      ChimpagneSupply(
+          id = "a", unit = "bananas", quantity = 3, assignedTo = hashMapOf("hector" to true))
 
   @Test
   fun supplyCardTest() {
@@ -32,14 +32,14 @@ class SupplyScreenComponentsUITests {
   fun supplyAccountEntryTest() {
     composeTestRule.setContent {
       SupplyDialogAccountEntry(
-        account = TEST_ACCOUNTS[0],
-        loggedUserUID = TEST_ACCOUNTS[0].firebaseAuthUID,
-        showCheckBox = true)
+          account = TEST_ACCOUNTS[0],
+          loggedUserUID = TEST_ACCOUNTS[0].firebaseAuthUID,
+          showCheckBox = true)
     }
 
     composeTestRule
-      .onNodeWithTag("supply_account_entry", useUnmergedTree = true)
-      .assertHasClickAction()
+        .onNodeWithTag("supply_account_entry", useUnmergedTree = true)
+        .assertHasClickAction()
     composeTestRule.onNodeWithTag("supply_account_checkbox", useUnmergedTree = true).assertExists()
   }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/MainActivity.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/MainActivity.kt
@@ -29,6 +29,7 @@ import com.monkeyteam.chimpagne.ui.MyEventsScreen
 import com.monkeyteam.chimpagne.ui.ViewDetailEventScreen
 import com.monkeyteam.chimpagne.ui.event.EditEventScreen
 import com.monkeyteam.chimpagne.ui.event.EventCreationScreen
+import com.monkeyteam.chimpagne.ui.event.details.supplies.SuppliesScreen
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.ui.navigation.Route
 import com.monkeyteam.chimpagne.ui.theme.AccountCreation
@@ -168,6 +169,23 @@ class MainActivity : ComponentActivity() {
                   navObject = navActions,
                   eventViewModel = eventViewModel,
                   accountViewModel = accountViewModel)
+            }
+            composable(Route.SUPPLIES_SCREEN + "/{EventID}") { backStackEntry ->
+              val eventViewModel: EventViewModel =
+                viewModel(
+                  factory =
+                  EventViewModel.EventViewModelFactory(
+                    backStackEntry.arguments?.getString("EventID"), database))
+              eventViewModel.fetchEvent({
+                accountViewModel.fetchAccounts(
+                  listOf(eventViewModel.uiState.value.ownerId) +
+                          eventViewModel.uiState.value.staffs.keys.toList() +
+                          eventViewModel.uiState.value.guests.keys.toList())
+              })
+              SuppliesScreen(
+                navObject = navActions,
+                eventViewModel = eventViewModel,
+                accountViewModel = accountViewModel)
             }
           }
         }

--- a/app/src/main/java/com/monkeyteam/chimpagne/MainActivity.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/MainActivity.kt
@@ -172,20 +172,20 @@ class MainActivity : ComponentActivity() {
             }
             composable(Route.SUPPLIES_SCREEN + "/{EventID}") { backStackEntry ->
               val eventViewModel: EventViewModel =
-                viewModel(
-                  factory =
-                  EventViewModel.EventViewModelFactory(
-                    backStackEntry.arguments?.getString("EventID"), database))
+                  viewModel(
+                      factory =
+                          EventViewModel.EventViewModelFactory(
+                              backStackEntry.arguments?.getString("EventID"), database))
               eventViewModel.fetchEvent({
                 accountViewModel.fetchAccounts(
-                  listOf(eventViewModel.uiState.value.ownerId) +
-                          eventViewModel.uiState.value.staffs.keys.toList() +
-                          eventViewModel.uiState.value.guests.keys.toList())
+                    listOf(eventViewModel.uiState.value.ownerId) +
+                        eventViewModel.uiState.value.staffs.keys.toList() +
+                        eventViewModel.uiState.value.guests.keys.toList())
               })
               SuppliesScreen(
-                navObject = navActions,
-                eventViewModel = eventViewModel,
-                accountViewModel = accountViewModel)
+                  navObject = navActions,
+                  eventViewModel = eventViewModel,
+                  accountViewModel = accountViewModel)
             }
           }
         }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
@@ -484,11 +484,7 @@ fun ViewDetailEventScreen(navObject: NavigationActions, eventViewModel: EventVie
                                         .testTag("supplies"),
                                 onClick = {
                                   /* TODO Implement this later */
-                                  Toast.makeText(
-                                          context,
-                                          "This function will be implemented in a future version",
-                                          Toast.LENGTH_SHORT)
-                                      .show()
+                                  navObject.navigateTo(Route.SUPPLIES_SCREEN + "/" + uiState.id)
                                 })
                             Spacer(Modifier.height(16.dp))
                             ChimpagneButton(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/EditSupplyDialog.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/EditSupplyDialog.kt
@@ -1,6 +1,5 @@
 package com.monkeyteam.chimpagne.ui.event.details.supplies
 
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
@@ -52,35 +51,33 @@ fun EditSupplyDialog(
                         unit = unit))
                 onDismissRequest()
               })) {
-        Row(Modifier.fillMaxWidth()) {
-          OutlinedTextField(
-              modifier = Modifier.weight(0.50f).padding(5.dp).testTag("supplies_quantity_field"),
-              maxLines = 1,
-              value = quantity,
-              onValueChange = {
-                if ((it.toIntOrNull() ?: -1) > 0) {
-                  if (quantity == "0") {
-                    if (it.first() == '0') quantity = it.drop(1) else quantity = it.dropLast(1)
-                  } else quantity = it
-                }
-                if (it == "") quantity = "0"
-              },
-              keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-              textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.Center),
-              placeholder = { Text(stringResource(id = R.string.supplies_quantity)) })
-          OutlinedTextField(
-              modifier = Modifier.weight(0.50f).padding(5.dp).testTag("supplies_unit_field"),
-              maxLines = 1,
-              value = unit,
-              onValueChange = { unit = it },
-              placeholder = { Text(stringResource(id = R.string.supplies_unit)) })
-        }
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth().padding(5.dp).testTag("supplies_quantity_field"),
+            maxLines = 1,
+            value = quantity,
+            onValueChange = {
+              if ((it.toIntOrNull() ?: -1) > 0) {
+                if (quantity == "0") {
+                  if (it.first() == '0') quantity = it.drop(1) else quantity = it.dropLast(1)
+                } else quantity = it
+              }
+              if (it == "") quantity = "0"
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            label = { Text(stringResource(id = R.string.supplies_quantity)) })
+
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth().padding(5.dp).testTag("supplies_unit_field"),
+            maxLines = 1,
+            value = unit,
+            onValueChange = { unit = it },
+            label = { Text(stringResource(id = R.string.supplies_unit)) })
 
         OutlinedTextField(
             modifier = Modifier.fillMaxWidth().padding(5.dp).testTag("supplies_description_field"),
             maxLines = 1,
             value = description,
             onValueChange = { description = it },
-            placeholder = { Text(stringResource(id = R.string.supplies_description)) })
+            label = { Text(stringResource(id = R.string.supplies_description)) })
       }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/EditSupplyDialog.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/EditSupplyDialog.kt
@@ -3,7 +3,6 @@ package com.monkeyteam.chimpagne.ui.event.details.supplies
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.database.ChimpagneSupply

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/GuestSupplyDialog.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/GuestSupplyDialog.kt
@@ -34,20 +34,21 @@ fun GuestSupplyDialog(
                   stringResource(id = R.string.chimpagne_cancel),
                   onClick = onDismissRequest,
                   modifier = Modifier.testTag("guest_supply_cancel")),
-              if (supply.assignedTo.containsKey(loggedUserUID))
-                  ButtonData(
-                      stringResource(id = R.string.supplies_unassign_myself),
-                      modifier = Modifier.testTag("guest_supply_unassign")) {
-                        assignMyself(false)
-                        onDismissRequest()
-                      }
-              else
-                  ButtonData(
-                      stringResource(id = R.string.supplies_assign_myself),
-                      modifier = Modifier.testTag("guest_supply_assign")) {
-                        assignMyself(true)
-                        onDismissRequest()
-                      })) {
+              if (supply.assignedTo.containsKey(loggedUserUID)) {
+                ButtonData(
+                    stringResource(id = R.string.supplies_unassign_myself),
+                    modifier = Modifier.testTag("guest_supply_unassign")) {
+                      assignMyself(false)
+                      onDismissRequest()
+                    }
+              } else {
+                ButtonData(
+                    stringResource(id = R.string.supplies_assign_myself),
+                    modifier = Modifier.testTag("guest_supply_assign")) {
+                      assignMyself(true)
+                      onDismissRequest()
+                    }
+              })) {
         Column(modifier = Modifier.fillMaxWidth()) {
           if (supply.assignedTo.keys.isEmpty()) {
             Text(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/GuestSupplyDialog.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/GuestSupplyDialog.kt
@@ -1,0 +1,71 @@
+package com.monkeyteam.chimpagne.ui.event.details.supplies
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccount
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
+import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
+import com.monkeyteam.chimpagne.ui.components.ButtonData
+import com.monkeyteam.chimpagne.ui.components.CustomDialog
+
+@Composable
+fun GuestSupplyDialog(
+    supply: ChimpagneSupply,
+    assignMyself: (Boolean) -> Unit,
+    loggedUserUID: ChimpagneAccountUID,
+    accounts: Map<ChimpagneAccountUID, ChimpagneAccount?>,
+    onDismissRequest: () -> Unit
+) {
+  CustomDialog(
+      title = "${supply.quantity} ${supply.unit}",
+      description = supply.description,
+      onDismissRequest = onDismissRequest,
+      modifier = Modifier.testTag("guest_supply_dialog"),
+      buttonDataList =
+          listOf(
+              ButtonData(
+                  stringResource(id = R.string.chimpagne_cancel),
+                  onClick = onDismissRequest,
+                  modifier = Modifier.testTag("guest_supply_cancel")),
+              if (supply.assignedTo.containsKey(loggedUserUID))
+                  ButtonData(
+                      stringResource(id = R.string.supplies_unassign_myself),
+                      modifier = Modifier.testTag("guest_supply_unassign")) {
+                        assignMyself(false)
+                        onDismissRequest()
+                      }
+              else
+                  ButtonData(
+                      stringResource(id = R.string.supplies_assign_myself),
+                      modifier = Modifier.testTag("guest_supply_assign")) {
+                        assignMyself(true)
+                        onDismissRequest()
+                      })) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+          if (supply.assignedTo.keys.isEmpty()) {
+            Text(
+                stringResource(id = R.string.supplies_supply_not_assigned),
+                modifier = Modifier.testTag("nobody_assigned"))
+          } else {
+            Text(stringResource(id = R.string.supplies_supply_assigned_to))
+            LazyColumn {
+              supply.assignedTo.entries.forEach { (userUID, isAssigned) ->
+                if (isAssigned) {
+                  item {
+                    SupplyDialogAccountEntry(
+                        account = accounts[userUID], loggedUserUID = loggedUserUID)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/StaffSupplyDialog.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/StaffSupplyDialog.kt
@@ -95,36 +95,37 @@ fun StaffSupplyDialog(
                   stringResource(id = R.string.supplies_supply_assigned_to),
                   modifier = Modifier.testTag("staff_list"))
             }
-            accounts.entries.forEach { (userUID, userAccount) ->
-              if (tempSupply.assignedTo[userUID] == true) {
-                item {
-                  SupplyDialogAccountEntry(
-                      account = userAccount,
-                      loggedUserUID = loggedUserUID,
-                      showCheckBox = true,
-                      true) {
-                        tempSupply = tempSupply.copy(assignedTo = tempSupply.assignedTo - userUID)
-                      }
+            accounts.entries
+                .filter { (userUID) -> tempSupply.assignedTo[userUID] == true }
+                .forEach { (userUID, userAccount) ->
+                  item {
+                    SupplyDialogAccountEntry(
+                        account = userAccount,
+                        loggedUserUID = loggedUserUID,
+                        showCheckBox = true,
+                        true) {
+                          tempSupply = tempSupply.copy(assignedTo = tempSupply.assignedTo - userUID)
+                        }
+                  }
                 }
-              }
-            }
           }
           if (!tempSupply.assignedTo.keys.containsAll(accounts.keys)) {
             item { Text(stringResource(id = R.string.supplies_not_assigned_to)) }
-            accounts.entries.forEach { (userUID, userAccount) ->
-              if (tempSupply.assignedTo[userUID] != true) {
-                item {
-                  SupplyDialogAccountEntry(
-                      account = userAccount,
-                      loggedUserUID = loggedUserUID,
-                      showCheckBox = true,
-                      false) {
-                        tempSupply =
-                            tempSupply.copy(assignedTo = tempSupply.assignedTo + (userUID to true))
-                      }
+            accounts.entries
+                .filter { (userUID) -> tempSupply.assignedTo[userUID] != true }
+                .forEach { (userUID, userAccount) ->
+                  item {
+                    SupplyDialogAccountEntry(
+                        account = userAccount,
+                        loggedUserUID = loggedUserUID,
+                        showCheckBox = true,
+                        false) {
+                          tempSupply =
+                              tempSupply.copy(
+                                  assignedTo = tempSupply.assignedTo + (userUID to true))
+                        }
+                  }
                 }
-              }
-            }
           }
         }
       }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/StaffSupplyDialog.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/StaffSupplyDialog.kt
@@ -1,0 +1,131 @@
+package com.monkeyteam.chimpagne.ui.event.details.supplies
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccount
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
+import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
+import com.monkeyteam.chimpagne.ui.components.ButtonData
+import com.monkeyteam.chimpagne.ui.components.CustomDialog
+
+@Composable
+fun StaffSupplyDialog(
+    supply: ChimpagneSupply,
+    updateSupply: (ChimpagneSupply) -> Unit,
+    deleteSupply: () -> Unit,
+    loggedUserUID: ChimpagneAccountUID,
+    accounts: Map<ChimpagneAccountUID, ChimpagneAccount?>,
+    onDismissRequest: () -> Unit
+) {
+  var tempSupply by remember { mutableStateOf(supply) }
+
+  var displayDeleteSupplyDialog by remember { mutableStateOf(false) }
+  if (displayDeleteSupplyDialog) {
+    CustomDialog(
+        title = stringResource(id = R.string.supplies_delete),
+        description = stringResource(id = R.string.supplies_delete_description),
+        onDismissRequest = { displayDeleteSupplyDialog = false },
+        buttonDataList =
+            listOf(
+                ButtonData(
+                    stringResource(id = R.string.chimpagne_cancel),
+                    modifier = Modifier.testTag("cancel_delete_button")) {
+                      displayDeleteSupplyDialog = false
+                    },
+                ButtonData(
+                    stringResource(id = R.string.chimpagne_confirm),
+                    modifier = Modifier.testTag("confirm_delete_button")) {
+                      deleteSupply()
+                      onDismissRequest()
+                    }))
+  }
+
+  var displayEditSupplyDialog by remember { mutableStateOf(false) }
+  if (displayEditSupplyDialog) {
+    EditSupplyDialog(
+        supply = tempSupply,
+        onDismissRequest = { displayEditSupplyDialog = false },
+        onSave = { tempSupply = it })
+  }
+
+  CustomDialog(
+      title = "${tempSupply.quantity} ${tempSupply.unit}",
+      description = tempSupply.description,
+      onDismissRequest = onDismissRequest,
+      modifier = Modifier.testTag("staff_supply_dialog"),
+      buttonDataList =
+          listOf(
+              ButtonData(
+                  stringResource(id = R.string.chimpagne_cancel),
+                  onClick = onDismissRequest,
+                  modifier = Modifier.testTag("cancel_supply_button")),
+              ButtonData(
+                  stringResource(id = R.string.chimpagne_delete),
+                  modifier = Modifier.testTag("delete_supply_button")) {
+                    displayDeleteSupplyDialog = true
+                  },
+              ButtonData(
+                  stringResource(id = R.string.chimpagne_edit),
+                  modifier = Modifier.testTag("edit_supply_button")) {
+                    displayEditSupplyDialog = true
+                  },
+              ButtonData(
+                  stringResource(id = R.string.chimpagne_save),
+                  modifier = Modifier.testTag("save_supply_button")) {
+                    displayEditSupplyDialog = false
+                    updateSupply(tempSupply)
+                    onDismissRequest()
+                  })) {
+        LazyColumn(modifier = Modifier.fillMaxWidth()) {
+          if (tempSupply.assignedTo.keys.isEmpty()) {
+            item { Text(stringResource(id = R.string.supplies_supply_not_assigned)) }
+          } else {
+            item {
+              Text(
+                  stringResource(id = R.string.supplies_supply_assigned_to),
+                  modifier = Modifier.testTag("staff_list"))
+            }
+            accounts.entries.forEach { (userUID, userAccount) ->
+              if (tempSupply.assignedTo[userUID] == true) {
+                item {
+                  SupplyDialogAccountEntry(
+                      account = userAccount,
+                      loggedUserUID = loggedUserUID,
+                      showCheckBox = true,
+                      true) {
+                        tempSupply = tempSupply.copy(assignedTo = tempSupply.assignedTo - userUID)
+                      }
+                }
+              }
+            }
+          }
+          if (!tempSupply.assignedTo.keys.containsAll(accounts.keys)) {
+            item { Text(stringResource(id = R.string.supplies_not_assigned_to)) }
+            accounts.entries.forEach { (userUID, userAccount) ->
+              if (tempSupply.assignedTo[userUID] != true) {
+                item {
+                  SupplyDialogAccountEntry(
+                      account = userAccount,
+                      loggedUserUID = loggedUserUID,
+                      showCheckBox = true,
+                      false) {
+                        tempSupply =
+                            tempSupply.copy(assignedTo = tempSupply.assignedTo + (userUID to true))
+                      }
+                }
+              }
+            }
+          }
+        }
+      }
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
@@ -7,12 +7,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -32,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
+import com.monkeyteam.chimpagne.ui.components.GoBackButton
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
@@ -137,11 +136,7 @@ fun SuppliesScreen(
         TopAppBar(
             title = { Text(stringResource(id = R.string.supplies_screen_title)) },
             modifier = Modifier.shadow(4.dp),
-            navigationIcon = {
-              IconButton(onClick = { navObject.goBack() }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-              }
-            })
+            navigationIcon = { GoBackButton(navObject) })
       }) { innerPadding ->
         if (eventUiState.supplies.isEmpty()) {
           Text(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
@@ -39,74 +39,75 @@ import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SuppliesScreen(
-  navObject: NavigationActions,
-  eventViewModel: EventViewModel,
-  accountViewModel: AccountViewModel
+    navObject: NavigationActions,
+    eventViewModel: EventViewModel,
+    accountViewModel: AccountViewModel
 ) {
   val eventUiState by eventViewModel.uiState.collectAsState()
   val accountsUiState by accountViewModel.uiState.collectAsState()
 
   val suppliesAssignedToMe =
-    eventUiState.supplies.filter {
-      it.value.assignedTo.containsKey(accountsUiState.currentUserUID!!)
-    }
+      eventUiState.supplies.filter {
+        it.value.assignedTo.containsKey(accountsUiState.currentUserUID!!)
+      }
   val nonAssignedSupplies = eventUiState.supplies.filter { it.value.assignedTo.isEmpty() }
   val otherSupplies =
-    eventUiState.supplies.filter {
-      it.value.assignedTo.isNotEmpty() &&
-              !it.value.assignedTo.containsKey(accountsUiState.currentUserUID)
-    }
+      eventUiState.supplies.filter {
+        it.value.assignedTo.isNotEmpty() &&
+            !it.value.assignedTo.containsKey(accountsUiState.currentUserUID)
+      }
 
   var displayAddPopup by remember { mutableStateOf(false) }
   if (displayAddPopup) {
     EditSupplyDialog(
-      supply = ChimpagneSupply(),
-      onDismissRequest = { displayAddPopup = false },
-      onSave = { eventViewModel.updateSupplyAtomically(it) })
+        supply = ChimpagneSupply(),
+        onDismissRequest = { displayAddPopup = false },
+        onSave = { eventViewModel.updateSupplyAtomically(it) })
   }
 
   var displayedSupply by remember { mutableStateOf(ChimpagneSupply()) }
   var displayAssignPopup by remember { mutableStateOf(false) }
   if (displayAssignPopup) {
+    println("BANANA ${eventUiState.currentUserRole}")
     if (eventUiState.currentUserRole == ChimpagneRole.GUEST) {
       GuestSupplyDialog(
-        supply = displayedSupply,
-        assignMyself = {
-          if (it) {
-            eventViewModel.assignSupplyAtomically(
-              displayedSupply.id, accountsUiState.currentUserUID!!)
-          } else {
-            eventViewModel.unassignSupplyAtomically(
-              displayedSupply.id, accountsUiState.currentUserUID!!)
-          }
-          displayAssignPopup = false
-          displayedSupply = ChimpagneSupply()
-        },
-        loggedUserUID = accountsUiState.currentUserUID!!,
-        accounts = accountsUiState.fetchedAccounts,
-        onDismissRequest = {
-          displayAssignPopup = false
-          displayedSupply = ChimpagneSupply()
-        })
+          supply = displayedSupply,
+          assignMyself = {
+            if (it) {
+              eventViewModel.assignSupplyAtomically(
+                  displayedSupply.id, accountsUiState.currentUserUID!!)
+            } else {
+              eventViewModel.unassignSupplyAtomically(
+                  displayedSupply.id, accountsUiState.currentUserUID!!)
+            }
+            displayAssignPopup = false
+            displayedSupply = ChimpagneSupply()
+          },
+          loggedUserUID = accountsUiState.currentUserUID!!,
+          accounts = accountsUiState.fetchedAccounts,
+          onDismissRequest = {
+            displayAssignPopup = false
+            displayedSupply = ChimpagneSupply()
+          })
     } else {
       StaffSupplyDialog(
-        supply = displayedSupply,
-        updateSupply = { eventViewModel.updateSupplyAtomically(it) },
-        deleteSupply = { eventViewModel.removeSupplyAtomically(displayedSupply.id) },
-        loggedUserUID = accountsUiState.currentUserUID!!,
-        accounts = accountsUiState.fetchedAccounts,
-        onDismissRequest = {
-          displayAssignPopup = false
-          displayedSupply = ChimpagneSupply()
-        })
+          supply = displayedSupply,
+          updateSupply = { eventViewModel.updateSupplyAtomically(it) },
+          deleteSupply = { eventViewModel.removeSupplyAtomically(displayedSupply.id) },
+          loggedUserUID = accountsUiState.currentUserUID!!,
+          accounts = accountsUiState.fetchedAccounts,
+          onDismissRequest = {
+            displayAssignPopup = false
+            displayedSupply = ChimpagneSupply()
+          })
     }
   }
 
   @Composable
   fun DisplaySupplyListIfNotEmpty(
-    listTitle: String,
-    supplyList: List<ChimpagneSupply>,
-    testTag: String
+      listTitle: String,
+      supplyList: List<ChimpagneSupply>,
+      testTag: String
   ) {
     if (supplyList.isNotEmpty()) {
       Text(text = listTitle, modifier = Modifier.padding(12.dp, 8.dp))
@@ -124,50 +125,50 @@ fun SuppliesScreen(
   }
 
   Scaffold(
-    floatingActionButton = {
-      if (listOf(ChimpagneRole.OWNER, ChimpagneRole.STAFF)
-          .contains(eventUiState.currentUserRole)) {
-        FloatingActionButton(
-          onClick = { displayAddPopup = true }, modifier = Modifier.testTag("supply_add")) {
-          Icon(Icons.Default.Add, contentDescription = "Add")
+      floatingActionButton = {
+        if (listOf(ChimpagneRole.OWNER, ChimpagneRole.STAFF)
+            .contains(eventUiState.currentUserRole)) {
+          FloatingActionButton(
+              onClick = { displayAddPopup = true }, modifier = Modifier.testTag("supply_add")) {
+                Icon(Icons.Default.Add, contentDescription = "Add")
+              }
+        }
+      },
+      topBar = {
+        TopAppBar(
+            title = { Text(stringResource(id = R.string.supplies_screen_title)) },
+            modifier = Modifier.shadow(4.dp),
+            navigationIcon = {
+              IconButton(onClick = { navObject.goBack() }) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
+              }
+            })
+      }) { innerPadding ->
+        if (eventUiState.supplies.isEmpty()) {
+          Text(
+              text = stringResource(id = R.string.supplies_empty),
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .fillMaxHeight()
+                      .padding(innerPadding)
+                      .wrapContentHeight(align = Alignment.CenterVertically)
+                      .testTag("supply_nothing"),
+              textAlign = TextAlign.Center)
+        } else {
+          Column(Modifier.padding(innerPadding)) {
+            DisplaySupplyListIfNotEmpty(
+                listTitle = stringResource(id = R.string.supplies_supply_assigned_to_you),
+                supplyList = suppliesAssignedToMe.values.toList(),
+                testTag = "assigned_you")
+            DisplaySupplyListIfNotEmpty(
+                listTitle = stringResource(id = R.string.supplies_not_assigned_to_anyone),
+                supplyList = nonAssignedSupplies.values.toList(),
+                testTag = "assigned_nobody")
+            DisplaySupplyListIfNotEmpty(
+                listTitle = stringResource(id = R.string.supplies_already_assigned),
+                supplyList = otherSupplies.values.toList(),
+                testTag = "assigned_other")
+          }
         }
       }
-    },
-    topBar = {
-      TopAppBar(
-        title = { Text(stringResource(id = R.string.supplies_screen_title)) },
-        modifier = Modifier.shadow(4.dp),
-        navigationIcon = {
-          IconButton(onClick = { navObject.goBack() }) {
-            Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-          }
-        })
-    }) { innerPadding ->
-    if (eventUiState.supplies.isEmpty()) {
-      Text(
-        text = stringResource(id = R.string.supplies_empty),
-        modifier =
-        Modifier.fillMaxWidth()
-          .fillMaxHeight()
-          .padding(innerPadding)
-          .wrapContentHeight(align = Alignment.CenterVertically)
-          .testTag("supply_nothing"),
-        textAlign = TextAlign.Center)
-    } else {
-      Column(Modifier.padding(innerPadding)) {
-        DisplaySupplyListIfNotEmpty(
-          listTitle = stringResource(id = R.string.supplies_supply_assigned_to_you),
-          supplyList = suppliesAssignedToMe.values.toList(),
-          testTag = "assigned_you")
-        DisplaySupplyListIfNotEmpty(
-          listTitle = stringResource(id = R.string.supplies_not_assigned_to_anyone),
-          supplyList = nonAssignedSupplies.values.toList(),
-          testTag = "assigned_nobody")
-        DisplaySupplyListIfNotEmpty(
-          listTitle = stringResource(id = R.string.supplies_already_assigned),
-          supplyList = otherSupplies.values.toList(),
-          testTag = "assigned_other")
-      }
-    }
-  }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
@@ -1,0 +1,173 @@
+package com.monkeyteam.chimpagne.ui.event.details.supplies
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.model.database.ChimpagneRole
+import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
+import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
+import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
+import com.monkeyteam.chimpagne.viewmodels.EventViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SuppliesScreen(
+  navObject: NavigationActions,
+  eventViewModel: EventViewModel,
+  accountViewModel: AccountViewModel
+) {
+  val eventUiState by eventViewModel.uiState.collectAsState()
+  val accountsUiState by accountViewModel.uiState.collectAsState()
+
+  val suppliesAssignedToMe =
+    eventUiState.supplies.filter {
+      it.value.assignedTo.containsKey(accountsUiState.currentUserUID!!)
+    }
+  val nonAssignedSupplies = eventUiState.supplies.filter { it.value.assignedTo.isEmpty() }
+  val otherSupplies =
+    eventUiState.supplies.filter {
+      it.value.assignedTo.isNotEmpty() &&
+              !it.value.assignedTo.containsKey(accountsUiState.currentUserUID)
+    }
+
+  var displayAddPopup by remember { mutableStateOf(false) }
+  if (displayAddPopup) {
+    EditSupplyDialog(
+      supply = ChimpagneSupply(),
+      onDismissRequest = { displayAddPopup = false },
+      onSave = { eventViewModel.updateSupplyAtomically(it) })
+  }
+
+  var displayedSupply by remember { mutableStateOf(ChimpagneSupply()) }
+  var displayAssignPopup by remember { mutableStateOf(false) }
+  if (displayAssignPopup) {
+    if (eventUiState.currentUserRole == ChimpagneRole.GUEST) {
+      GuestSupplyDialog(
+        supply = displayedSupply,
+        assignMyself = {
+          if (it) {
+            eventViewModel.assignSupplyAtomically(
+              displayedSupply.id, accountsUiState.currentUserUID!!)
+          } else {
+            eventViewModel.unassignSupplyAtomically(
+              displayedSupply.id, accountsUiState.currentUserUID!!)
+          }
+          displayAssignPopup = false
+          displayedSupply = ChimpagneSupply()
+        },
+        loggedUserUID = accountsUiState.currentUserUID!!,
+        accounts = accountsUiState.fetchedAccounts,
+        onDismissRequest = {
+          displayAssignPopup = false
+          displayedSupply = ChimpagneSupply()
+        })
+    } else {
+      StaffSupplyDialog(
+        supply = displayedSupply,
+        updateSupply = { eventViewModel.updateSupplyAtomically(it) },
+        deleteSupply = { eventViewModel.removeSupplyAtomically(displayedSupply.id) },
+        loggedUserUID = accountsUiState.currentUserUID!!,
+        accounts = accountsUiState.fetchedAccounts,
+        onDismissRequest = {
+          displayAssignPopup = false
+          displayedSupply = ChimpagneSupply()
+        })
+    }
+  }
+
+  @Composable
+  fun DisplaySupplyListIfNotEmpty(
+    listTitle: String,
+    supplyList: List<ChimpagneSupply>,
+    testTag: String
+  ) {
+    if (supplyList.isNotEmpty()) {
+      Text(text = listTitle, modifier = Modifier.padding(12.dp, 8.dp))
+      LazyColumn(modifier = Modifier.testTag(testTag)) {
+        supplyList.forEach { supply ->
+          item {
+            SupplyCard(supply = supply) {
+              displayedSupply = supply
+              displayAssignPopup = true
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Scaffold(
+    floatingActionButton = {
+      if (listOf(ChimpagneRole.OWNER, ChimpagneRole.STAFF)
+          .contains(eventUiState.currentUserRole)) {
+        FloatingActionButton(
+          onClick = { displayAddPopup = true }, modifier = Modifier.testTag("supply_add")) {
+          Icon(Icons.Default.Add, contentDescription = "Add")
+        }
+      }
+    },
+    topBar = {
+      TopAppBar(
+        title = { Text(stringResource(id = R.string.supplies_screen_title)) },
+        modifier = Modifier.shadow(4.dp),
+        navigationIcon = {
+          IconButton(onClick = { navObject.goBack() }) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
+          }
+        })
+    }) { innerPadding ->
+    if (eventUiState.supplies.isEmpty()) {
+      Text(
+        text = stringResource(id = R.string.supplies_empty),
+        modifier =
+        Modifier.fillMaxWidth()
+          .fillMaxHeight()
+          .padding(innerPadding)
+          .wrapContentHeight(align = Alignment.CenterVertically)
+          .testTag("supply_nothing"),
+        textAlign = TextAlign.Center)
+    } else {
+      Column(Modifier.padding(innerPadding)) {
+        DisplaySupplyListIfNotEmpty(
+          listTitle = stringResource(id = R.string.supplies_supply_assigned_to_you),
+          supplyList = suppliesAssignedToMe.values.toList(),
+          testTag = "assigned_you")
+        DisplaySupplyListIfNotEmpty(
+          listTitle = stringResource(id = R.string.supplies_not_assigned_to_anyone),
+          supplyList = nonAssignedSupplies.values.toList(),
+          testTag = "assigned_nobody")
+        DisplaySupplyListIfNotEmpty(
+          listTitle = stringResource(id = R.string.supplies_already_assigned),
+          supplyList = otherSupplies.values.toList(),
+          testTag = "assigned_other")
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
@@ -68,7 +68,6 @@ fun SuppliesScreen(
   var displayedSupply by remember { mutableStateOf(ChimpagneSupply()) }
   var displayAssignPopup by remember { mutableStateOf(false) }
   if (displayAssignPopup) {
-    println("BANANA ${eventUiState.currentUserRole}")
     if (eventUiState.currentUserRole == ChimpagneRole.GUEST) {
       GuestSupplyDialog(
           supply = displayedSupply,

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SupplyCard.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SupplyCard.kt
@@ -13,7 +13,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
 
 @Composable
@@ -33,7 +35,8 @@ fun SupplyCard(supply: ChimpagneSupply, modifier: Modifier = Modifier, onClick: 
                   text = "${supply.quantity} ${supply.unit}",
                   modifier = Modifier.testTag("supply_quantity_and_unit"))
               Text(
-                  text = "${supply.assignedTo.keys.size} assigned",
+                  text =
+                      "${supply.assignedTo.keys.size} ${stringResource(id = R.string.supplies_nb_assigned)}",
                   modifier = Modifier.testTag("supply_nb_assigned"))
             }
       }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SupplyCard.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SupplyCard.kt
@@ -1,0 +1,40 @@
+package com.monkeyteam.chimpagne.ui.event.details.supplies
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
+
+@Composable
+fun SupplyCard(supply: ChimpagneSupply, modifier: Modifier = Modifier, onClick: () -> Unit) {
+  Card(
+      modifier =
+          modifier
+              .clickable { onClick() }
+              .padding(horizontal = 16.dp, vertical = 8.dp)
+              .fillMaxWidth(),
+      shape = RoundedCornerShape(16.dp),
+      colors = CardDefaults.cardColors(MaterialTheme.colorScheme.primary)) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+              Text(
+                  text = "${supply.quantity} ${supply.unit}",
+                  modifier = Modifier.testTag("supply_quantity_and_unit"))
+              Text(
+                  text = "${supply.assignedTo.keys.size} assigned",
+                  modifier = Modifier.testTag("supply_nb_assigned"))
+            }
+      }
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SupplyDialogAccountEntry.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SupplyDialogAccountEntry.kt
@@ -24,12 +24,12 @@ fun SupplyDialogAccountEntry(
 ) {
   ListItem(
       headlineContent = {
-        Text(
-            text =
-                "${account?.firstName} ${account?.lastName}" +
-                    if (account!!.firebaseAuthUID == loggedUserUID)
-                        " (${stringResource(id = R.string.chimpagne_you)})"
-                    else "")
+        val accountName = "${account?.firstName} ${account?.lastName}"
+        val accountIsYou =
+            if (account!!.firebaseAuthUID == loggedUserUID)
+                " (${stringResource(id = R.string.chimpagne_you)})"
+            else ""
+        Text(text = accountName + accountIsYou)
       },
       colors = ListItemDefaults.colors(containerColor = Color.Transparent),
       trailingContent = {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SupplyDialogAccountEntry.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SupplyDialogAccountEntry.kt
@@ -1,0 +1,44 @@
+package com.monkeyteam.chimpagne.ui.event.details.supplies
+
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccount
+import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
+
+@Composable
+fun SupplyDialogAccountEntry(
+    account: ChimpagneAccount?,
+    loggedUserUID: ChimpagneAccountUID,
+    showCheckBox: Boolean = false,
+    checked: Boolean = false,
+    onCheck: (Boolean) -> Unit = {}
+) {
+  ListItem(
+      headlineContent = {
+        Text(
+            text =
+                "${account?.firstName} ${account?.lastName}" +
+                    if (account!!.firebaseAuthUID == loggedUserUID)
+                        " (${stringResource(id = R.string.chimpagne_you)})"
+                    else "")
+      },
+      colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+      trailingContent = {
+        if (showCheckBox) {
+          Checkbox(
+              checked = checked,
+              onCheckedChange = onCheck,
+              modifier = Modifier.testTag("supply_account_checkbox"))
+        }
+      },
+      modifier = Modifier.clickable { onCheck(!checked) }.testTag("supply_account_entry"))
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/navigation/NavigationActions.kt
@@ -16,6 +16,7 @@ object Route {
   const val MY_EVENTS_SCREEN = "myEvents"
   const val VIEW_DETAIL_EVENT_SCREEN = "viewDetailEventScreen"
   const val MANAGE_STAFF_SCREEN = "manageStaffScreen"
+  const val SUPPLIES_SCREEN = "SuppliesScreen"
 }
 
 class NavigationActions(private val navController: NavHostController) {

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -190,6 +190,14 @@ class EventViewModel(
   fun leaveTheEvent(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     _uiState.value = _uiState.value.copy(loading = true)
     viewModelScope.launch {
+      val accountUID = accountManager.currentUserAccount!!.firebaseAuthUID
+      _uiState.value.supplies
+          .filter { (_, supply) -> supply.assignedTo[accountUID] == true }
+          .keys
+          .forEach { supplyId ->
+            eventManager.atomic.unassignSupply(_uiState.value.id, supplyId, accountUID)
+          }
+
       accountManager.leaveEvent(
           _uiState.value.id,
           {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -31,6 +31,8 @@
     <string name="event_creation_screen_parking">Parking</string>
     <string name="event_creation_screen_number_parking">Nombre de places de parque</string>
     <string name="event_creation_screen_number_beds">Nombre de lits</string>
+    <string name="event_creation_screen_supplies">Fournitures</string>
+    <string name="event_creation_screen_add_supplies">Ajouter des fournitures</string>
     <string name="event_creation_screen_beds">Lits</string>
     <string name="close">Fermer</string>
     <string name="find_event_page_title">Trouver une soirée</string>
@@ -49,8 +51,6 @@
     <string name="find_event_location_not_selected">Sélectionnez un lieu</string>
     <string name="search_location">Rechercher un lieu</string>
     <string name="accountEditScreenButton">Modifier le compte</string>
-    <string name="chimpagne_cancel">Annuler</string>
-    <string name="chimpagne_add">Ajouter</string>
     <string name="sign_in_with_google">Se connecter avec Google</string>
     <string name="welcome_screen_title">Bienvenue à</string>
     <string name="save_changes">Sauvegarder les changements</string>
@@ -73,6 +73,7 @@
     <string name="event_details_screen_manage_staff_button">Gérer le personnel</string>
     <string name="event_details_screen_chat_button">Discussion</string>
     <string name="event_details_screen_location_button">Localisation</string>
+    <string name="event_details_screen_supplies_button">Fournitures</string>
     <string name="event_details_screen_voting_button">Votes et sondages</string>
     <string name="event_details_screen_car_pooling_button">Covoiturages</string>
     <string name="edit_event">Editer l\'événement</string>
@@ -90,14 +91,32 @@
     <string name="manage_staff_screen_guest_list_name">Liste des invités:</string>
     <string name="manage_staff_screen_empty_guest_list">Il n\'y a pas d\'invités à cette événement</string>
 
-    <!--  Supplies  -->
-    <string name="event_creation_screen_supplies">Courses</string>
-    <string name="event_creation_screen_add_supplies">Ajouter des courses</string>
-    <string name="event_details_screen_supplies_button">Trucs à amener</string>
+    <!-- Chimpagne -->
+    <string name="chimpagne_cancel">Annuler</string>
+    <string name="chimpagne_edit">Éditer</string>
+    <string name="chimpagne_save">Sauvegarder</string>
+    <string name="chimpagne_confirm">Confirmer</string>
+    <string name="chimpagne_add">Ajouter</string>
+    <string name="chimpagne_delete">Supprimer</string>
+    <string name="chimpagne_you">Vous</string>
+
+    <!--    Supplies    -->
+    <string name="supplies_screen_title">Liste de fournitures</string>
+    <string name="supplies_dialog_description">Détails de la fourniture</string>
+    <string name="supplies_edit_dialog_title">Édition de la fourniture</string>
+    <string name="supplies_add_dialog_title">Ajouter une fourniture</string>
     <string name="supplies_description">Description</string>
     <string name="supplies_quantity">Quantité</string>
     <string name="supplies_unit">Unité</string>
-
-    <string name="supplies_add_dialog_title">Ajouter une fourniture</string>
-    <string name="supplies_dialog_description">Détails de la fourniture</string>
+    <string name="supplies_assign_myself">M\'assigner</string>
+    <string name="supplies_unassign_myself">Me désassigner</string>
+    <string name="supplies_supply_not_assigned">Cette fourniture n\'est pas assignée !</string>
+    <string name="supplies_supply_assigned_to">Personnes assignées</string>
+    <string name="supplies_not_assigned_to">Personnes non assignées</string>
+    <string name="supplies_supply_assigned_to_you">Fournitures assignées à vous</string>
+    <string name="supplies_not_assigned_to_anyone">Fournitures assignées à personnes</string>
+    <string name="supplies_already_assigned">Fournitures déjà assignées</string>
+    <string name="supplies_empty">Aucune fourniture ajoutée !</string>
+    <string name="supplies_delete">Supprimer cette fourniture ?</string>
+    <string name="supplies_delete_description">Cette action est irreversible !</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -125,9 +125,6 @@
     <string name="supplies_delete_description">Cette action est irreversible !</string>
     <string name="supplies_nb_assigned">assignés</string>
 
-    <string name="supplies_add_dialog_title">Ajouter une fourniture</string>
-    <string name="supplies_dialog_description">Détails de la fourniture</string>
-
     <!-- AccountCreation -->
     <string name="account_created_toast">Compte créé</string>
     <string name="acount_creation_failed_toast">Création de compte échouée</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -112,7 +112,7 @@
     <string name="supplies_quantity">Quantité</string>
     <string name="supplies_unit">Unité</string>
     <string name="supplies_assign_myself">M\'assigner</string>
-    <string name="supplies_unassign_myself">Me désassigner</string>
+    <string name="supplies_unassign_myself">Me retirer</string>
     <string name="supplies_supply_not_assigned">Cette fourniture n\'est pas assignée !</string>
     <string name="supplies_supply_assigned_to">Personnes assignées</string>
     <string name="supplies_not_assigned_to">Personnes non assignées</string>
@@ -122,4 +122,5 @@
     <string name="supplies_empty">Aucune fourniture ajoutée !</string>
     <string name="supplies_delete">Supprimer cette fourniture ?</string>
     <string name="supplies_delete_description">Cette action est irreversible !</string>
+    <string name="supplies_nb_assigned">assignés</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,9 +125,6 @@
     <string name="supplies_delete_description">This action is irreversible !</string>
     <string name="supplies_nb_assigned">assigned</string>
 
-    <string name="supplies_add_dialog_title">Add a supply</string>
-    <string name="supplies_dialog_description">Enter the supply details</string>
-
     <!-- DeepLinks -->
     <string name="deep_link_url_event" translatable="false">https://www.manigo.ch/events/?uid=</string>
     <string name="deep_link_url_event_host" translatable="false">www.manigo.ch</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,7 +116,7 @@
     <string name="supplies_supply_assigned_to_you">Supplies assigned to you</string>
     <string name="supplies_not_assigned_to_anyone">Supplies not assigned to anyone</string>
     <string name="supplies_already_assigned">Supplies already assigned</string>
-    <string name="supplies_empty">No created supply</string>
+    <string name="supplies_empty">No supply created</string>
     <string name="supplies_delete">Delete this supply ?</string>
     <string name="supplies_delete_description">This action is irreversible !</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,8 @@
     <string name="event_creation_screen_number_parking">Number of parking places</string>
     <string name="event_creation_screen_number_beds">Number of beds</string>
     <string name="event_creation_screen_beds">Beds</string>
+    <string name="event_creation_screen_supplies">Supplies</string>
+    <string name="event_creation_screen_add_supplies">Add supplies</string>
     <string name="accountEditScreenButton">Edit Account</string>
     <string name="find_event_page_title">Find Event</string>
     <string name="find_event_search_button_text">Search</string>
@@ -71,10 +73,9 @@
     <string name="event_details_screen_manage_staff_button">Manage staff</string>
     <string name="event_details_screen_chat_button">Chat</string>
     <string name="event_details_screen_location_button">Location</string>
+    <string name="event_details_screen_supplies_button">Supplies</string>
     <string name="event_details_screen_voting_button">Polls and voting</string>
     <string name="event_details_screen_car_pooling_button">Car pooling</string>
-    <string name="chimpagne_cancel">Cancel</string>
-    <string name="chimpagne_add">Add</string>
     <string name="edit_event">Edit event</string>
     <string name="edit_event_toast_finish">The event has been edited !</string>
     <string name="edit_event_save_failure">Could not save the edited event !</string>
@@ -90,14 +91,32 @@
     <string name="manage_staff_screen_guest_list_name">Guest List:</string>
     <string name="manage_staff_screen_empty_guest_list">There are no guests in this event:</string>
 
-    <!--  Supplies  -->
-    <string name="event_creation_screen_supplies">Supplies</string>
-    <string name="event_creation_screen_add_supplies">Add supplies</string>
-    <string name="event_details_screen_supplies_button">Supplies</string>
+    <!-- Chimpagne -->
+    <string name="chimpagne_cancel">Cancel</string>
+    <string name="chimpagne_edit">Edit</string>
+    <string name="chimpagne_save">Save</string>
+    <string name="chimpagne_confirm">Confirm</string>
+    <string name="chimpagne_add">Add</string>
+    <string name="chimpagne_delete">Delete</string>
+    <string name="chimpagne_you">You</string>
+
+    <!--    Supplies    -->
+    <string name="supplies_screen_title">Supplies to bring</string>
+    <string name="supplies_dialog_description">Enter the supply details</string>
+    <string name="supplies_edit_dialog_title">Edit the supply</string>
+    <string name="supplies_add_dialog_title">Add a supply</string>
     <string name="supplies_description">Description</string>
     <string name="supplies_quantity">Quantity</string>
     <string name="supplies_unit">Unit</string>
-
-    <string name="supplies_add_dialog_title">Add a supply</string>
-    <string name="supplies_dialog_description">Enter the supply details</string>
+    <string name="supplies_assign_myself">Assign myself</string>
+    <string name="supplies_unassign_myself">Unassign myself</string>
+    <string name="supplies_supply_not_assigned">Supply not assigned !</string>
+    <string name="supplies_supply_assigned_to">Supply already assigned to</string>
+    <string name="supplies_not_assigned_to">Supply not assigned to</string>
+    <string name="supplies_supply_assigned_to_you">Supplies assigned to you</string>
+    <string name="supplies_not_assigned_to_anyone">Supplies not assigned to anyone</string>
+    <string name="supplies_already_assigned">Supplies already assigned</string>
+    <string name="supplies_empty">No created supply</string>
+    <string name="supplies_delete">Delete this supply ?</string>
+    <string name="supplies_delete_description">This action is irreversible !</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,7 +113,7 @@
     <string name="supplies_quantity">Quantity</string>
     <string name="supplies_unit">Unit</string>
     <string name="supplies_assign_myself">Assign myself</string>
-    <string name="supplies_unassign_myself">Unassign myself</string>
+    <string name="supplies_unassign_myself">Remove myself</string>
     <string name="supplies_supply_not_assigned">Supply not assigned !</string>
     <string name="supplies_supply_assigned_to">Supply already assigned to</string>
     <string name="supplies_not_assigned_to">Supply not assigned to</string>
@@ -123,4 +123,5 @@
     <string name="supplies_empty">No supply created</string>
     <string name="supplies_delete">Delete this supply ?</string>
     <string name="supplies_delete_description">This action is irreversible !</string>
+    <string name="supplies_nb_assigned">assigned</string>
 </resources>


### PR DESCRIPTION
This PR adds the supplies screen to the detailed event page. From there, if you're a staff, you can add / edit / delte / assign supplies. As a guest, you can only assign / unassign yourself from a supply.

A new route (SUPPLIES_SCREEN) has been added.

Here are some screens:

- Staff perspective
![image](https://github.com/Chimpagne/ChimpagneApp/assets/39198541/7e8a635f-30e7-4a45-8d77-c5e1d1dfc4d5)
![image](https://github.com/Chimpagne/ChimpagneApp/assets/39198541/e369b373-d232-4a81-9f4f-5150a670aeae)
![image](https://github.com/Chimpagne/ChimpagneApp/assets/39198541/3bc42b6c-04e6-4aa5-b245-120d8fb84956)

- Guest perspective
![image](https://github.com/Chimpagne/ChimpagneApp/assets/39198541/dd13958a-7f50-4e58-9e72-67b475167cea)
![image](https://github.com/Chimpagne/ChimpagneApp/assets/39198541/a4953c2c-4a78-4103-ae57-0b216248b1b9)
