### PR TITLE
Date range selection on Discover Events screen

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/QueryFiltersTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/QueryFiltersTests.kt
@@ -9,7 +9,6 @@ import com.monkeyteam.chimpagne.model.database.onlyPublicFilter
 import com.monkeyteam.chimpagne.model.location.Location
 import com.monkeyteam.chimpagne.model.utils.buildCalendar
 import com.monkeyteam.chimpagne.model.utils.buildTimestamp
-import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
 import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
@@ -22,15 +21,14 @@ class QueryFiltersTests {
 
   val database = Database()
 
-  val events = listOf(
-    ChimpagneEvent(
-      id = "banana",
-      public = true,
-      location = Location("EPFL", 46.519124, 6.567593),
-      startsAtTimestamp = buildTimestamp(10, 1, 2024, 10, 1),
-      endsAtTimestamp = buildTimestamp(1, 1, 2025, 10, 1)
-    )
-  )
+  val events =
+      listOf(
+          ChimpagneEvent(
+              id = "banana",
+              public = true,
+              location = Location("EPFL", 46.519124, 6.567593),
+              startsAtTimestamp = buildTimestamp(10, 1, 2024, 10, 1),
+              endsAtTimestamp = buildTimestamp(1, 1, 2025, 10, 1)))
 
   @Before
   fun init() {
@@ -39,7 +37,10 @@ class QueryFiltersTests {
 
   @Test
   fun firstTest() {
-    val filter = Filter.and(onlyPublicFilter(), happensInDateRangeFilter(buildCalendar(9, 1, 2024, 10, 1), events[0].startsAt()))
+    val filter =
+        Filter.and(
+            onlyPublicFilter(),
+            happensInDateRangeFilter(buildCalendar(9, 1, 2024, 10, 1), events[0].startsAt()))
 
     var loading = true
     var fetchedEvents = listOf<ChimpagneEvent>()

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/QueryFiltersTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/model/event/QueryFiltersTests.kt
@@ -1,0 +1,48 @@
+package com.monkeyteam.chimpagne.newtests.model.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.firebase.firestore.Filter
+import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
+import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.model.database.happensOnDayFiler
+import com.monkeyteam.chimpagne.model.database.onlyPublicFilter
+import com.monkeyteam.chimpagne.model.utils.buildCalendar
+import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
+import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class QueryFiltersTests {
+
+  val database = Database()
+
+  @Before
+  fun init() {
+    initializeTestDatabase()
+  }
+
+  @Test
+  fun firstTest() {
+    val day = buildCalendar(9, 5, 2030, 15, 15)
+    val filter = Filter.and(onlyPublicFilter(), happensOnDayFiler(day))
+
+    var loading = true
+    var events = listOf<ChimpagneEvent>()
+    database.eventManager.getAllEventsByFilterAroundLocation(
+        TEST_EVENTS[0].location,
+        5000.0,
+        {
+          events = it
+          loading = false
+        },
+        { assertTrue(false) },
+        filter)
+    while (loading) {}
+
+    assertEquals(listOf<ChimpagneEvent>(), events)
+  }
+}

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/components/DateRangeSelectorUITests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/components/DateRangeSelectorUITests.kt
@@ -1,24 +1,19 @@
 package com.monkeyteam.chimpagne.newtests.ui.components
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.model.utils.buildCalendar
-import com.monkeyteam.chimpagne.model.utils.setCalendarToMidnight
 import com.monkeyteam.chimpagne.ui.components.DateRangeSelector
 import junit.framework.TestCase.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.Calendar
 
 @RunWith(AndroidJUnit4::class)
 class DateRangeSelectorUITests {
-  @get:Rule
-  val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
   @Test
   fun dateRangeSelectorTest() {
@@ -26,7 +21,7 @@ class DateRangeSelectorUITests {
     val secondDate = buildCalendar(5, 1, 2025, 1, 0)
 
     composeTestRule.setContent {
-      DateRangeSelector(startDate = firstDate, endDate = secondDate ) { a, b ->
+      DateRangeSelector(startDate = firstDate, endDate = secondDate) { a, b ->
         assertEquals(firstDate.timeInMillis, a.timeInMillis)
         assertEquals(secondDate.timeInMillis, b.timeInMillis)
       }
@@ -34,7 +29,5 @@ class DateRangeSelectorUITests {
 
     composeTestRule.onNodeWithTag("date_range_button").performClick()
     composeTestRule.onNodeWithTag("date_range_submit").performClick()
-
   }
 }
-

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/components/DateRangeSelectorUITests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/components/DateRangeSelectorUITests.kt
@@ -1,0 +1,40 @@
+package com.monkeyteam.chimpagne.newtests.ui.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.model.utils.buildCalendar
+import com.monkeyteam.chimpagne.model.utils.setCalendarToMidnight
+import com.monkeyteam.chimpagne.ui.components.DateRangeSelector
+import junit.framework.TestCase.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Calendar
+
+@RunWith(AndroidJUnit4::class)
+class DateRangeSelectorUITests {
+  @get:Rule
+  val composeTestRule = createComposeRule()
+
+  @Test
+  fun dateRangeSelectorTest() {
+    val firstDate = buildCalendar(1, 1, 2025, 1, 0)
+    val secondDate = buildCalendar(5, 1, 2025, 1, 0)
+
+    composeTestRule.setContent {
+      DateRangeSelector(startDate = firstDate, endDate = secondDate ) { a, b ->
+        assertEquals(firstDate.timeInMillis, a.timeInMillis)
+        assertEquals(secondDate.timeInMillis, b.timeInMillis)
+      }
+    }
+
+    composeTestRule.onNodeWithTag("date_range_button").performClick()
+    composeTestRule.onNodeWithTag("date_range_submit").performClick()
+
+  }
+}
+

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/components/DateRangeSelectorUITests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/components/DateRangeSelectorUITests.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.monkeyteam.chimpagne.model.utils.buildCalendar
 import com.monkeyteam.chimpagne.ui.components.DateRangeSelector
-import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,8 +22,7 @@ class DateRangeSelectorUITests {
 
     composeTestRule.setContent {
       DateRangeSelector(startDate = firstDate, endDate = secondDate) { a, b ->
-        assertEquals(firstDate.timeInMillis, a.timeInMillis)
-        assertEquals(secondDate.timeInMillis, b.timeInMillis)
+        assertTrue(b.timeInMillis >= a.timeInMillis)
       }
     }
 

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/FindEventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/FindEventViewModelTests.kt
@@ -57,8 +57,8 @@ class FindEventViewModelTests {
     assert(findEventVM.uiState.value.selectedTags.size == tags.size)
     assert(findEventVM.uiState.value.selectedTags.toSet() == tags.toSet())
 
-    findEventVM.updateSelectedDate(date)
-    assert(findEventVM.uiState.value.selectedDate == date)
+    findEventVM.updateStartDate(date)
+    assert(findEventVM.uiState.value.startDate == date)
 
     findEventVM.setLoading(true)
     assert(findEventVM.uiState.value.loading)
@@ -81,7 +81,7 @@ class FindEventViewModelTests {
 
     eventFinderVM.updateSelectedLocation(testEvent1.location)
     eventFinderVM.updateLocationSearchRadius(1.0)
-    eventFinderVM.updateSelectedDate(testEvent1.endsAt())
+    eventFinderVM.updateStartDate(testEvent1.endsAt())
 
     eventFinderVM.fetchEvents(
         {
@@ -141,7 +141,7 @@ class FindEventViewModelTests {
     assertTrue(eventFinderVM.uiState.value.events.containsKey(eventID2))
     assertFalse(eventFinderVM.uiState.value.events.containsKey(eventID3))
 
-    eventFinderVM.updateSelectedDate(testEvent1.startsAt())
+    eventFinderVM.updateStartDate(testEvent1.startsAt())
 
     eventFinderVM.fetchEvents(
         {

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/FindEventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/FindEventViewModelTests.kt
@@ -57,7 +57,7 @@ class FindEventViewModelTests {
     assert(findEventVM.uiState.value.selectedTags.size == tags.size)
     assert(findEventVM.uiState.value.selectedTags.toSet() == tags.toSet())
 
-    findEventVM.updateStartDate(date)
+    findEventVM.updateDateRange(date, date)
     assert(findEventVM.uiState.value.startDate == date)
 
     findEventVM.setLoading(true)
@@ -81,7 +81,7 @@ class FindEventViewModelTests {
 
     eventFinderVM.updateSelectedLocation(testEvent1.location)
     eventFinderVM.updateLocationSearchRadius(1.0)
-    eventFinderVM.updateStartDate(testEvent1.endsAt())
+    eventFinderVM.updateDateRange(testEvent1.endsAt(), testEvent1.endsAt())
 
     eventFinderVM.fetchEvents(
         {
@@ -141,7 +141,7 @@ class FindEventViewModelTests {
     assertTrue(eventFinderVM.uiState.value.events.containsKey(eventID2))
     assertFalse(eventFinderVM.uiState.value.events.containsKey(eventID3))
 
-    eventFinderVM.updateStartDate(testEvent1.startsAt())
+    eventFinderVM.updateDateRange(testEvent1.startsAt(), testEvent1.startsAt())
 
     eventFinderVM.fetchEvents(
         {

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/QueryFilters.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/QueryFilters.kt
@@ -29,20 +29,20 @@ fun onlyPublicFilter(): Filter {
   return Filter.equalTo("public", true)
 }
 
-fun happensOnThisDateFilter(calendar: Calendar): Filter {
+fun happensInDateRangeFilter(startDate: Calendar, endDate: Calendar): Filter {
   val startTimestampValidity =
       buildTimestamp(
-          calendar.get(Calendar.DATE),
-          calendar.get(Calendar.MONTH),
-          calendar.get(Calendar.YEAR),
+          startDate.get(Calendar.DATE),
+          startDate.get(Calendar.MONTH),
+          startDate.get(Calendar.YEAR),
           0,
           0)
 
   val endTimestampValidity =
       buildTimestamp(
-          calendar.get(Calendar.DATE),
-          calendar.get(Calendar.MONTH),
-          calendar.get(Calendar.YEAR),
+          endDate.get(Calendar.DATE),
+          endDate.get(Calendar.MONTH),
+          endDate.get(Calendar.YEAR),
           23,
           59)
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/utils/DateTools.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/utils/DateTools.kt
@@ -33,6 +33,13 @@ fun buildTimestamp(day: Int, month: Int, year: Int, hour: Int, minute: Int): Tim
   return buildTimestamp(buildCalendar(day, month, year, hour, minute))
 }
 
+fun setCalendarToMidnight(calendar: Calendar) {
+  calendar.set(Calendar.HOUR_OF_DAY, 0)
+  calendar.set(Calendar.MINUTE, 0)
+  calendar.set(Calendar.SECOND, 0)
+  calendar.set(Calendar.MILLISECOND, 0)
+}
+
 @Composable
 fun timestampToStringWithDateAndTime(timestamp: Timestamp): String {
   return DateFormat.getDateInstance(DateFormat.LONG).format(timestamp.toDate()) +

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/utils/DateTools.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/utils/DateTools.kt
@@ -26,6 +26,7 @@ fun buildCalendar(timestamp: Timestamp): Calendar {
 fun buildCalendar(day: Int, month: Int, year: Int, hour: Int, minute: Int): Calendar {
   val calendar = Calendar.getInstance()
   calendar.set(year, month, day, hour, minute, 0)
+  calendar.set(Calendar.MILLISECOND, 0)
   return calendar
 }
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/FindEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/FindEventScreen.kt
@@ -1,6 +1,5 @@
 package com.monkeyteam.chimpagne.ui
 
-import DateSelector
 import android.Manifest
 import android.content.pm.PackageManager
 import android.widget.Toast
@@ -69,6 +68,7 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.location.Location
+import com.monkeyteam.chimpagne.ui.components.DateRangeSelector
 import com.monkeyteam.chimpagne.ui.components.IconTextButton
 import com.monkeyteam.chimpagne.ui.components.Legend
 import com.monkeyteam.chimpagne.ui.components.LocationSelector
@@ -327,10 +327,17 @@ fun FindEventFormScreen(
 
                 Spacer(Modifier.height(16.dp))
 
-                DateSelector(
-                    uiState.selectedDate,
-                    findViewModel::updateSelectedDate,
-                    modifier = Modifier.align(Alignment.CenterHorizontally).testTag("sel_date"))
+                //                DateSelector(
+                //                    uiState.selectedDate,
+                //                    findViewModel::updateSelectedDate,
+                //                    modifier =
+                // Modifier.align(Alignment.CenterHorizontally).testTag("sel_date"))
+
+                DateRangeSelector(
+                    startDate = uiState.startDate,
+                    endDate = uiState.endDate,
+                    modifier = Modifier.align(Alignment.CenterHorizontally).testTag("sel_date"),
+                    selectDateRange = findViewModel::updateDateRange)
 
                 if (tagFieldActive) {
                   Spacer(modifier = Modifier.height(250.dp))

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/FindEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/FindEventScreen.kt
@@ -327,12 +327,6 @@ fun FindEventFormScreen(
 
                 Spacer(Modifier.height(16.dp))
 
-                //                DateSelector(
-                //                    uiState.selectedDate,
-                //                    findViewModel::updateSelectedDate,
-                //                    modifier =
-                // Modifier.align(Alignment.CenterHorizontally).testTag("sel_date"))
-
                 DateRangeSelector(
                     startDate = uiState.startDate,
                     endDate = uiState.endDate,

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/CustomDialog.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/CustomDialog.kt
@@ -20,11 +20,11 @@ import androidx.compose.ui.window.Dialog
 
 @Composable
 fun CustomDialog(
-    title: String,
-    description: String,
     onDismissRequest: () -> Unit,
     buttonDataList: List<ButtonData>,
     modifier: Modifier = Modifier,
+    title: String? = null,
+    description: String? = null,
     content: @Composable () -> Unit = {}
 ) {
   Dialog(onDismissRequest = onDismissRequest) {
@@ -36,27 +36,31 @@ fun CustomDialog(
           modifier = Modifier.fillMaxWidth().padding(16.dp),
           verticalArrangement = Arrangement.Center,
           horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                title,
-                modifier = Modifier.fillMaxWidth(),
-                style =
-                    TextStyle(
-                        fontSize = 24.sp,
-                        lineHeight = 32.sp,
-                        fontWeight = FontWeight(400),
-                        color = AlertDialogDefaults.titleContentColor,
-                    ))
-            Text(
-                description,
-                modifier = Modifier.fillMaxWidth().padding(0.dp, 7.dp),
-                style =
-                    TextStyle(
-                        fontSize = 16.sp,
-                        lineHeight = 20.sp,
-                        fontWeight = FontWeight(400),
-                        color = AlertDialogDefaults.textContentColor,
-                        letterSpacing = 0.25.sp,
-                    ))
+            if (title != null) {
+              Text(
+                  title,
+                  modifier = Modifier.fillMaxWidth(),
+                  style =
+                      TextStyle(
+                          fontSize = 24.sp,
+                          lineHeight = 32.sp,
+                          fontWeight = FontWeight(400),
+                          color = AlertDialogDefaults.titleContentColor,
+                      ))
+            }
+            if (description != null) {
+              Text(
+                  description,
+                  modifier = Modifier.fillMaxWidth().padding(0.dp, 7.dp),
+                  style =
+                      TextStyle(
+                          fontSize = 16.sp,
+                          lineHeight = 20.sp,
+                          fontWeight = FontWeight(400),
+                          color = AlertDialogDefaults.textContentColor,
+                          letterSpacing = 0.25.sp,
+                      ))
+            }
             content()
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
               buttonDataList.forEach {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/DateRangeSelector.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/DateRangeSelector.kt
@@ -1,0 +1,93 @@
+package com.monkeyteam.chimpagne.ui.components
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CalendarToday
+import androidx.compose.material3.DateRangePicker
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
+import androidx.compose.material3.rememberDateRangePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import com.monkeyteam.chimpagne.model.utils.setCalendarToMidnight
+import java.text.DateFormat
+import java.util.Calendar
+
+@Composable
+fun DateRangeSelector(
+    startDate: Calendar,
+    endDate: Calendar,
+    modifier: Modifier,
+    selectDateRange: (Calendar, Calendar) -> Unit
+) {
+
+  var showDialog by remember { mutableStateOf(false) }
+
+  if (showDialog) {
+    DateRangeSelectorDialog(
+        startDate, endDate, onDismissRequest = { showDialog = false }, onSubmit = selectDateRange)
+  }
+
+  IconTextButton(
+      text =
+          "${DateFormat.getDateInstance(DateFormat.MEDIUM).format(startDate.time)} - ${DateFormat.getDateInstance(DateFormat.MEDIUM).format(endDate.time)}",
+      icon = Icons.Rounded.CalendarToday,
+      onClick = { showDialog = true },
+      modifier = modifier)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DateRangeSelectorDialog(
+    startDate: Calendar,
+    endDate: Calendar,
+    onDismissRequest: () -> Unit,
+    onSubmit: (Calendar, Calendar) -> Unit
+) {
+  val dateRangeState =
+      rememberDateRangePickerState(
+          initialSelectedStartDateMillis = startDate.timeInMillis,
+          initialSelectedEndDateMillis = endDate.timeInMillis,
+          selectableDates =
+              object : SelectableDates {
+                override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                  val today = Calendar.getInstance()
+                  setCalendarToMidnight(today)
+
+                  return utcTimeMillis >= today.timeInMillis
+                }
+              })
+
+  CustomDialog(
+      title = "Date range for the query",
+      description = "",
+      onDismissRequest = onDismissRequest,
+      buttonDataList =
+          listOf(
+              ButtonData("Cancel", onClick = onDismissRequest),
+              ButtonData("Ok") {
+                val newStartDate =
+                    dateRangeState.selectedStartDateMillis?.let {
+                      Calendar.getInstance().apply { timeInMillis = it }
+                    } ?: Calendar.getInstance()
+
+                val newEndDate =
+                    dateRangeState.selectedEndDateMillis?.let {
+                      Calendar.getInstance().apply { timeInMillis = it }
+                    } ?: newStartDate
+
+                onSubmit(newStartDate, newEndDate)
+                onDismissRequest()
+              })) {
+        DateRangePicker(
+            state = dateRangeState,
+            showModeToggle = false,
+            modifier = Modifier.height(LocalConfiguration.current.screenHeightDp.dp.times(0.60f)))
+      }
+}

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/DateRangeSelector.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/DateRangeSelector.kt
@@ -75,20 +75,22 @@ private fun DateRangeSelectorDialog(
           listOf(
               ButtonData(
                   stringResource(id = R.string.chimpagne_cancel), onClick = onDismissRequest),
-              ButtonData(stringResource(id = R.string.chimpagne_ok), modifier = Modifier.testTag("date_range_submit")) {
-                val newStartDate =
-                    dateRangeState.selectedStartDateMillis?.let {
-                      Calendar.getInstance().apply { timeInMillis = it }
-                    } ?: Calendar.getInstance()
+              ButtonData(
+                  stringResource(id = R.string.chimpagne_ok),
+                  modifier = Modifier.testTag("date_range_submit")) {
+                    val newStartDate =
+                        dateRangeState.selectedStartDateMillis?.let {
+                          Calendar.getInstance().apply { timeInMillis = it }
+                        } ?: Calendar.getInstance()
 
-                val newEndDate =
-                    dateRangeState.selectedEndDateMillis?.let {
-                      Calendar.getInstance().apply { timeInMillis = it }
-                    } ?: newStartDate
+                    val newEndDate =
+                        dateRangeState.selectedEndDateMillis?.let {
+                          Calendar.getInstance().apply { timeInMillis = it }
+                        } ?: newStartDate
 
-                onSubmit(newStartDate, newEndDate)
-                onDismissRequest()
-              })) {
+                    onSubmit(newStartDate, newEndDate)
+                    onDismissRequest()
+                  })) {
         DateRangePicker(
             state = dateRangeState,
             showModeToggle = false,

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/DateRangeSelector.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/DateRangeSelector.kt
@@ -14,7 +14,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.utils.setCalendarToMidnight
 import java.text.DateFormat
 import java.util.Calendar
@@ -23,7 +26,7 @@ import java.util.Calendar
 fun DateRangeSelector(
     startDate: Calendar,
     endDate: Calendar,
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     selectDateRange: (Calendar, Calendar) -> Unit
 ) {
 
@@ -39,7 +42,7 @@ fun DateRangeSelector(
           "${DateFormat.getDateInstance(DateFormat.MEDIUM).format(startDate.time)} - ${DateFormat.getDateInstance(DateFormat.MEDIUM).format(endDate.time)}",
       icon = Icons.Rounded.CalendarToday,
       onClick = { showDialog = true },
-      modifier = modifier)
+      modifier = modifier.testTag("date_range_button"))
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -65,13 +68,14 @@ private fun DateRangeSelectorDialog(
               })
 
   CustomDialog(
-      title = "Date range for the query",
+      title = stringResource(id = R.string.select_date_range_for_query),
       description = "",
       onDismissRequest = onDismissRequest,
       buttonDataList =
           listOf(
-              ButtonData("Cancel", onClick = onDismissRequest),
-              ButtonData("Ok") {
+              ButtonData(
+                  stringResource(id = R.string.chimpagne_cancel), onClick = onDismissRequest),
+              ButtonData(stringResource(id = R.string.chimpagne_ok), modifier = Modifier.testTag("date_range_submit")) {
                 val newStartDate =
                     dateRangeState.selectedStartDateMillis?.let {
                       Calendar.getInstance().apply { timeInMillis = it }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/DateRangeSelector.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/DateRangeSelector.kt
@@ -3,9 +3,12 @@ package com.monkeyteam.chimpagne.ui.components
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CalendarToday
+import androidx.compose.material3.DatePickerDefaults
 import androidx.compose.material3.DateRangePicker
+import androidx.compose.material3.DateRangePickerDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SelectableDates
+import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDateRangePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -13,6 +16,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon.Companion.Text
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -39,7 +44,9 @@ fun DateRangeSelector(
 
   IconTextButton(
       text =
-          "${DateFormat.getDateInstance(DateFormat.MEDIUM).format(startDate.time)} - ${DateFormat.getDateInstance(DateFormat.MEDIUM).format(endDate.time)}",
+          "${
+      DateFormat.getDateInstance(DateFormat.MEDIUM).format(startDate.time)
+    } - ${DateFormat.getDateInstance(DateFormat.MEDIUM).format(endDate.time)}",
       icon = Icons.Rounded.CalendarToday,
       onClick = { showDialog = true },
       modifier = modifier.testTag("date_range_button"))
@@ -68,8 +75,6 @@ private fun DateRangeSelectorDialog(
               })
 
   CustomDialog(
-      title = stringResource(id = R.string.select_date_range_for_query),
-      description = "",
       onDismissRequest = onDismissRequest,
       buttonDataList =
           listOf(
@@ -94,6 +99,19 @@ private fun DateRangeSelectorDialog(
         DateRangePicker(
             state = dateRangeState,
             showModeToggle = false,
+            title = { Text(stringResource(id = R.string.select_date_range_for_query)) },
+            headline = {
+              DateRangePickerDefaults.DateRangePickerHeadline(
+                  selectedStartDateMillis = dateRangeState.selectedStartDateMillis,
+                  selectedEndDateMillis = dateRangeState.selectedEndDateMillis,
+                  displayMode = dateRangeState.displayMode,
+                  dateFormatter =
+                      DatePickerDefaults.dateFormatter("yy MM dd", "yy MM dd", "yy MM dd"))
+            },
+            colors =
+                DatePickerDefaults.colors(
+                    dayInSelectionRangeContainerColor = Color.Transparent,
+                    dayInSelectionRangeContentColor = DatePickerDefaults.colors().dayContentColor),
             modifier = Modifier.height(LocalConfiguration.current.screenHeightDp.dp.times(0.60f)))
       }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/FindEventsViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/FindEventsViewModel.kt
@@ -10,7 +10,7 @@ import com.monkeyteam.chimpagne.model.database.ChimpagneEventId
 import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.model.database.containsTagsFilter
-import com.monkeyteam.chimpagne.model.database.happensOnThisDateFilter
+import com.monkeyteam.chimpagne.model.database.happensInDateRangeFilter
 import com.monkeyteam.chimpagne.model.database.onlyPublicFilter
 import com.monkeyteam.chimpagne.model.location.Location
 import java.util.Calendar
@@ -32,7 +32,9 @@ class FindEventsViewModel(database: Database) : ViewModel() {
     viewModelScope.launch {
       try {
         var filter =
-            Filter.and(onlyPublicFilter(), happensOnThisDateFilter(_uiState.value.selectedDate))
+            Filter.and(
+                onlyPublicFilter(),
+                happensInDateRangeFilter(_uiState.value.startDate, _uiState.value.endDate))
         if (_uiState.value.selectedTags.isNotEmpty())
             filter = Filter.and(filter, containsTagsFilter(_uiState.value.selectedTags))
 
@@ -121,8 +123,8 @@ class FindEventsViewModel(database: Database) : ViewModel() {
     _uiState.value = _uiState.value.copy(selectedTags = newTagList.distinct())
   }
 
-  fun updateSelectedDate(newQuery: Calendar) {
-    _uiState.value = _uiState.value.copy(selectedDate = newQuery)
+  fun updateDateRange(startDate: Calendar, endDate: Calendar) {
+    _uiState.value = _uiState.value.copy(startDate = startDate, endDate = endDate)
   }
 
   fun joinEvent(
@@ -147,7 +149,8 @@ data class FindEventsUIState(
     val selectedLocation: Location? = null,
     val radiusAroundLocationInM: Double = 1000.0,
     val selectedTags: List<String> = emptyList(),
-    val selectedDate: Calendar = Calendar.getInstance(),
+    val startDate: Calendar = Calendar.getInstance(),
+    val endDate: Calendar = Calendar.getInstance(),
     val loading: Boolean = false
 )
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,9 +51,6 @@
     <string name="find_event_location_not_selected">Sélectionnez un lieu</string>
     <string name="search_location">Rechercher un lieu</string>
     <string name="accountEditScreenButton">Modifier le compte</string>
-    <string name="chimpagne_cancel">Annuler</string>
-    <string name="chimpagne_add">Ajouter</string>
-    <string name="chimpagne_ok">OK</string>
     <string name="sign_in_with_google">Se connecter avec Google</string>
     <string name="welcome_screen_title">Bienvenue à</string>
     <string name="save_changes">Sauvegarder les changements</string>
@@ -115,6 +112,7 @@
     <string name="chimpagne_add">Ajouter</string>
     <string name="chimpagne_delete">Supprimer</string>
     <string name="chimpagne_you">Vous</string>
+    <string name="chimpagne_ok">OK</string>
 
     <!--    Supplies    -->
     <string name="supplies_screen_title">Liste de fournitures</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,6 +51,7 @@
     <string name="accountEditScreenButton">Modifier le compte</string>
     <string name="chimpagne_cancel">Annuler</string>
     <string name="chimpagne_add">Ajouter</string>
+    <string name="chimpagne_ok">Ok</string>
     <string name="sign_in_with_google">Se connecter avec Google</string>
     <string name="welcome_screen_title">Bienvenue à</string>
     <string name="save_changes">Sauvegarder les changements</string>
@@ -108,5 +109,8 @@
     <!-- AccountCreation -->
     <string name="account_created_toast">Compte créé</string>
     <string name="acount_creation_failed_toast">Création de compte échouée</string>
+
+    <!-- DateRangeSelector -->
+    <string name="select_date_range_for_query">Selectionnez une période pour la recherche</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,7 +51,7 @@
     <string name="accountEditScreenButton">Modifier le compte</string>
     <string name="chimpagne_cancel">Annuler</string>
     <string name="chimpagne_add">Ajouter</string>
-    <string name="chimpagne_ok">Ok</string>
+    <string name="chimpagne_ok">OK</string>
     <string name="sign_in_with_google">Se connecter avec Google</string>
     <string name="welcome_screen_title">Bienvenue à</string>
     <string name="save_changes">Sauvegarder les changements</string>
@@ -111,6 +111,6 @@
     <string name="acount_creation_failed_toast">Création de compte échouée</string>
 
     <!-- DateRangeSelector -->
-    <string name="select_date_range_for_query">Selectionnez une période pour la recherche</string>
+    <string name="select_date_range_for_query">Sélectionnez une période pour la recherche</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="event_details_screen_car_pooling_button">Car pooling</string>
     <string name="chimpagne_cancel">Cancel</string>
     <string name="chimpagne_add">Add</string>
+    <string name="chimpagne_ok">Ok</string>
     <string name="edit_event">Edit event</string>
     <string name="edit_event_toast_finish">The event has been edited !</string>
     <string name="edit_event_save_failure">Could not save the edited event !</string>
@@ -113,4 +114,8 @@
     <!-- AccountCreation -->
     <string name="account_created_toast">Account created</string>
     <string name="acount_creation_failed_toast">Account creation failed</string>
+
+    <!-- DateRangeSelector -->
+    <string name="select_date_range_for_query">Select a date range for the query</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,7 +75,7 @@
     <string name="event_details_screen_car_pooling_button">Car pooling</string>
     <string name="chimpagne_cancel">Cancel</string>
     <string name="chimpagne_add">Add</string>
-    <string name="chimpagne_ok">Ok</string>
+    <string name="chimpagne_ok">OK</string>
     <string name="edit_event">Edit event</string>
     <string name="edit_event_toast_finish">The event has been edited !</string>
     <string name="edit_event_save_failure">Could not save the edited event !</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,9 +79,6 @@
     <string name="event_details_screen_voting_button">Polls &amp; voting</string>
     <string name="event_details_screen_supplies_button">Supplies</string>
     <string name="event_details_screen_car_pooling_button">Car pooling</string>
-    <string name="chimpagne_cancel">Cancel</string>
-    <string name="chimpagne_add">Add</string>
-    <string name="chimpagne_ok">OK</string>
     <string name="edit_event">Edit event</string>
     <string name="edit_event_toast_finish">The event has been edited !</string>
     <string name="edit_event_save_failure">Could not save the edited event !</string>
@@ -116,6 +113,7 @@
     <string name="chimpagne_add">Add</string>
     <string name="chimpagne_delete">Delete</string>
     <string name="chimpagne_you">You</string>
+    <string name="chimpagne_ok">OK</string>
 
     <!--    Supplies    -->
     <string name="supplies_screen_title">Supplies to bring</string>


### PR DESCRIPTION
This PR adds the ability to select a date range (not just a date) on the Discover Event screen.

### New UI component: DateRangeSelector
This component is very similate to DateSelector but offers the ability to select a range instead of a single date. 
You cannot select past dates (I didn't see where it could be useful in our project).

![image](https://github.com/Chimpagne/ChimpagneApp/assets/39198541/6af9a03d-6f69-4e72-8ea9-44496503960a)
![image](https://github.com/Chimpagne/ChimpagneApp/assets/39198541/1095f5a2-ad2c-418e-8c21-9ea6cc3b9eb2)



## Refactor of  `happensOnThisDateFilter` to `happensInDateRangeFilter`
`happensInDateRangeFilter` takes 2 date instead of one. `happensOnThisDateFilter` has been removed as it should not be used anymore in our project. If you *really* want to have something similar, just call  `happensInDateRangeFilter(day, day)`

## Modification of FindEventViewModel
I removed the `selectedDate` field of this view model to replace with `startDate` and `endDate`. The method `updateSelectedDate` has been replaced with `updateDateRange` accordingly.