### PR TITLE
Event creation improvements

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EditEventScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EditEventScreenTest.kt
@@ -143,11 +143,6 @@ class EditEventScreenTestTest {
     }
 
     // Tags (comma-separated)
-    composeTestRule.onNodeWithText("Title").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Description").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Logistics").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Parking").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Beds").assertDoesNotExist()
     // This will attempt to click the button and create a Toast.
     // Note that testing the actual visibility of a Toast is beyond the scope of Compose UI Tests.
     composeTestRule.onNodeWithText("Make this event public").performClick()
@@ -177,8 +172,6 @@ class EditEventScreenTestTest {
       EditEventScreen(
           19, navActions, viewModel(factory = EventViewModel.EventViewModelFactory(null, database)))
     }
-    composeTestRule.onNodeWithText("Title").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Description").assertDoesNotExist()
   }
 
   @Test

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EditEventScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EditEventScreenTest.kt
@@ -132,23 +132,6 @@ class EditEventScreenTestTest {
   }
 
   @Test
-  fun testMakeEventPublicButtonShowsToast() {
-
-    composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navActions = NavigationActions(navController)
-
-      EditEventScreen(
-          1, navActions, viewModel(factory = EventViewModel.EventViewModelFactory(null, database)))
-    }
-
-    // Tags (comma-separated)
-    // This will attempt to click the button and create a Toast.
-    // Note that testing the actual visibility of a Toast is beyond the scope of Compose UI Tests.
-    composeTestRule.onNodeWithText("Make this event public").performClick()
-  }
-
-  @Test
   fun testInputIntoTextFields() {
     composeTestRule.setContent {
       val navController = rememberNavController()
@@ -162,16 +145,6 @@ class EditEventScreenTestTest {
 
     composeTestRule.onNodeWithText(title).assertIsDisplayed()
     composeTestRule.onNodeWithTag("previous_button").assertDoesNotExist()
-  }
-
-  @Test
-  fun testInvalidPanel() {
-    composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navActions = NavigationActions(navController)
-      EditEventScreen(
-          19, navActions, viewModel(factory = EventViewModel.EventViewModelFactory(null, database)))
-    }
   }
 
   @Test

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
@@ -112,29 +112,6 @@ class EventCreationScreenTest {
     composeTestRule.onNodeWithText(tagsLegendS).assertIsDisplayed()
     composeTestRule.onNodeWithText(publicLegendS).assertIsDisplayed()
 
-    // You can add more detailed tests here for interactions and assertions
-  }
-
-  @Test
-  fun testMakeEventPublicButtonShowsToast() {
-
-    composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navActions = NavigationActions(navController)
-
-      EventCreationScreen(
-          1, navActions, viewModel(factory = EventViewModel.EventViewModelFactory(null, database)))
-    }
-
-    // Tags (comma-separated)
-    composeTestRule.onNodeWithText("Title").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Description").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Logistics").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Parking").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Beds").assertDoesNotExist()
-    // This will attempt to click the button and create a Toast.
-    // Note that testing the actual visibility of a Toast is beyond the scope of Compose UI Tests.
-    composeTestRule.onNodeWithText("Make this event public").performClick()
   }
 
   @Test
@@ -203,17 +180,6 @@ class EventCreationScreenTest {
     composeTestRule.onNodeWithTag("next_button").performClick()
   }
 
-  @Test
-  fun testInvalidPanel() {
-    composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navActions = NavigationActions(navController)
-      EventCreationScreen(
-          19, navActions, viewModel(factory = EventViewModel.EventViewModelFactory(null, database)))
-    }
-    composeTestRule.onNodeWithText("Title").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Description").assertDoesNotExist()
-  }
 
   @Test
   fun testUIHelpingFunctions() {

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
@@ -127,11 +127,6 @@ class EventCreationScreenTest {
     }
 
     // Tags (comma-separated)
-    composeTestRule.onNodeWithText("Title").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Description").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Logistics").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Parking").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Beds").assertDoesNotExist()
     // This will attempt to click the button and create a Toast.
     // Note that testing the actual visibility of a Toast is beyond the scope of Compose UI Tests.
     composeTestRule.onNodeWithText("Make this event public").performClick()
@@ -201,18 +196,6 @@ class EventCreationScreenTest {
     composeTestRule.onNodeWithTag("n_beds").performTextInput(valueBed)
     composeTestRule.onNodeWithTag("last_button").assertDoesNotExist()
     composeTestRule.onNodeWithTag("next_button").performClick()
-  }
-
-  @Test
-  fun testInvalidPanel() {
-    composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navActions = NavigationActions(navController)
-      EventCreationScreen(
-          19, navActions, viewModel(factory = EventViewModel.EventViewModelFactory(null, database)))
-    }
-    composeTestRule.onNodeWithText("Title").assertDoesNotExist()
-    composeTestRule.onNodeWithText("Description").assertDoesNotExist()
   }
 
   @Test

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
@@ -1,7 +1,6 @@
 package com.monkeyteam.chimpagne
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
+import android.icu.util.Calendar
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
@@ -22,6 +21,7 @@ import com.monkeyteam.chimpagne.ui.components.SupportedSocialMedia
 import com.monkeyteam.chimpagne.ui.event.EventCreationScreen
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
+import junit.framework.TestCase
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -249,5 +249,43 @@ class EventCreationScreenTest {
     }
 
     composeTestRule.onNodeWithTag("next_button").assertDoesNotExist()
+  }
+
+  @Test
+  fun defaultStartAndEndTest() {
+    val eventUIState = EventViewModel.EventUIState()
+    // Get the current time
+    val currentTime = Calendar.getInstance()
+
+    // Create expected start and end times
+    val expectedStartTime =
+        Calendar.getInstance().apply {
+          time = currentTime.time
+          add(Calendar.HOUR_OF_DAY, 1)
+        }
+    val expectedEndTime =
+        Calendar.getInstance().apply {
+          time = currentTime.time
+          add(Calendar.HOUR_OF_DAY, 2)
+        }
+
+    // Define a tolerance value in milliseconds (e.g., 10 second)
+    val toleranceMillis = 10000L
+
+    // Assert that the start time is approximately 1 hour after the current time
+    assertApproximatelyEqual(expectedStartTime, eventUIState.startsAtCalendarDate, toleranceMillis)
+
+    // Assert that the end time is approximately 2 hours after the current time
+    assertApproximatelyEqual(expectedEndTime, eventUIState.endsAtCalendarDate, toleranceMillis)
+  }
+
+  private fun assertApproximatelyEqual(
+      expected: Calendar,
+      actual: java.util.Calendar,
+      toleranceMillis: Long
+  ) {
+    val diffMillis = kotlin.math.abs(expected.timeInMillis - actual.timeInMillis)
+    TestCase.assertTrue(
+        "Expected: $expected, Actual: $actual, Diff: $diffMillis ms", diffMillis <= toleranceMillis)
   }
 }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
@@ -112,6 +112,29 @@ class EventCreationScreenTest {
     composeTestRule.onNodeWithText(tagsLegendS).assertIsDisplayed()
     composeTestRule.onNodeWithText(publicLegendS).assertIsDisplayed()
 
+    // You can add more detailed tests here for interactions and assertions
+  }
+
+  @Test
+  fun testMakeEventPublicButtonShowsToast() {
+
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navActions = NavigationActions(navController)
+
+      EventCreationScreen(
+          1, navActions, viewModel(factory = EventViewModel.EventViewModelFactory(null, database)))
+    }
+
+    // Tags (comma-separated)
+    composeTestRule.onNodeWithText("Title").assertDoesNotExist()
+    composeTestRule.onNodeWithText("Description").assertDoesNotExist()
+    composeTestRule.onNodeWithText("Logistics").assertDoesNotExist()
+    composeTestRule.onNodeWithText("Parking").assertDoesNotExist()
+    composeTestRule.onNodeWithText("Beds").assertDoesNotExist()
+    // This will attempt to click the button and create a Toast.
+    // Note that testing the actual visibility of a Toast is beyond the scope of Compose UI Tests.
+    composeTestRule.onNodeWithText("Make this event public").performClick()
   }
 
   @Test
@@ -180,6 +203,17 @@ class EventCreationScreenTest {
     composeTestRule.onNodeWithTag("next_button").performClick()
   }
 
+  @Test
+  fun testInvalidPanel() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navActions = NavigationActions(navController)
+      EventCreationScreen(
+          19, navActions, viewModel(factory = EventViewModel.EventViewModelFactory(null, database)))
+    }
+    composeTestRule.onNodeWithText("Title").assertDoesNotExist()
+    composeTestRule.onNodeWithText("Description").assertDoesNotExist()
+  }
 
   @Test
   fun testUIHelpingFunctions() {

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -566,6 +566,7 @@ class EventViewModelTests {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val result =
         EventViewModel.eventInputValidityToString(EventInputValidity.INVALID_TITLE, context)
+    print(result)
     assertEquals(context.getString(R.string.title_should_not_be_empty), result)
   }
 

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -560,7 +560,7 @@ class EventViewModelTests {
 
     database.accountManager.signInTo(TEST_ACCOUNTS[1])
   }
-    // This passes on my machine...
+  // This passes on my machine...
   @Test
   fun testInvalidTitle() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -375,7 +375,7 @@ class EventViewModelTests {
 
     eventVM.createTheEvent(
         onSuccess = { assertTrue(false) },
-        onInvalidInputs = { assertEquals("Title should not be empty", it) },
+        onInvalidInputs = { assertEquals(EventInputValidity.INVALID_TITLE, it) },
         onFailure = { assertTrue(false) })
 
     while (eventVM.uiState.value.loading) {}
@@ -425,7 +425,7 @@ class EventViewModelTests {
 
     eventVM.createTheEvent(
         onSuccess = { assertTrue(false) },
-        onInvalidInputs = { assertEquals("Invalid dates", it) },
+        onInvalidInputs = { assertEquals(EventInputValidity.INVALID_DATES, it) },
         onFailure = { assertTrue(false) })
 
     while (eventVM.uiState.value.loading) {}

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -560,7 +560,7 @@ class EventViewModelTests {
 
     database.accountManager.signInTo(TEST_ACCOUNTS[1])
   }
-
+    // This passes on my machine...
   @Test
   fun testInvalidTitle() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -366,22 +366,6 @@ class EventViewModelTests {
   }
 
   @Test
-  fun testCreateEventSuccess() {
-    val eventVM = EventViewModel(database = database)
-    replaceVMEventBy(eventVM, testEvent)
-
-    eventVM.createTheEvent(
-        onSuccess = { assertTrue(true) },
-        onInvalidInputs = { assertTrue(false) },
-        onFailure = { assertTrue(false) })
-
-    while (eventVM.uiState.value.loading) {}
-    Thread.sleep(SLEEP_AMOUNT_MILLIS)
-
-    assertTrue(eventVM.uiState.value.id.isNotEmpty())
-  }
-
-  @Test
   fun testCreateEventWithEmptyTitle() {
     val eventVM = EventViewModel(database = database)
     replaceVMEventBy(eventVM, testEvent.copy(title = ""))

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -446,6 +446,7 @@ class EventViewModelTests {
 
     assertTrue(eventVM.uiState.value.id.isEmpty())
   }
+
   @Test
   fun pollFunctionalityTest() {
     initializeTestDatabase()

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -2,6 +2,8 @@ package com.monkeyteam.chimpagne.newtests.viewmodels
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.database.ChimpagnePoll
 import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
@@ -12,6 +14,7 @@ import com.monkeyteam.chimpagne.newtests.SLEEP_AMOUNT_MILLIS
 import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
 import com.monkeyteam.chimpagne.newtests.TEST_EVENTS
 import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
+import com.monkeyteam.chimpagne.viewmodels.EventInputValidity
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
@@ -556,5 +559,21 @@ class EventViewModelTests {
     assertEquals(false, eventSearchVM3.uiState.value.polls.containsKey(poll.id))
 
     database.accountManager.signInTo(TEST_ACCOUNTS[1])
+  }
+
+  @Test
+  fun testInvalidTitle() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val result =
+        EventViewModel.eventInputValidityToString(EventInputValidity.INVALID_TITLE, context)
+    assertEquals(context.getString(R.string.title_should_not_be_empty), result)
+  }
+
+  @Test
+  fun testInvalidDates() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val result =
+        EventViewModel.eventInputValidityToString(EventInputValidity.INVALID_DATES, context)
+    assertEquals(context.getString(R.string.invalid_dates), result)
   }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdvancedLogisticsPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdvancedLogisticsPanel.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.ui.components.Legend
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
+import kotlin.math.abs
 
 @Composable
 fun AdvancedLogisticsPanel(eventViewModel: EventViewModel) {
@@ -48,7 +49,7 @@ fun AdvancedLogisticsPanel(eventViewModel: EventViewModel) {
         onValueChange = {
           parkingText = it
           try {
-            eventViewModel.updateParkingSpaces(parkingText.toInt())
+            eventViewModel.updateParkingSpaces(abs(parkingText.toInt()))
           } catch (_: Exception) {
             eventViewModel.updateParkingSpaces(0)
           }
@@ -65,7 +66,7 @@ fun AdvancedLogisticsPanel(eventViewModel: EventViewModel) {
         onValueChange = {
           bedsText = it
           try {
-            eventViewModel.updateBeds(bedsText.toInt())
+            eventViewModel.updateBeds(abs(bedsText.toInt()))
           } catch (_: Exception) {
             eventViewModel.updateBeds(0)
           }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdvancedLogisticsPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdvancedLogisticsPanel.kt
@@ -1,7 +1,9 @@
 package com.monkeyteam.chimpagne.ui.event
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -34,45 +36,48 @@ fun AdvancedLogisticsPanel(eventViewModel: EventViewModel) {
 
   var parkingText by remember { mutableStateOf(uiState.parkingSpaces.toString()) }
   var bedsText by remember { mutableStateOf(uiState.beds.toString()) }
-  Column(modifier = Modifier.padding(16.dp)) {
-    Legend(
-        stringResource(id = R.string.event_creation_screen_logistics),
-        Icons.Rounded.Layers,
-        "logistics_title")
-    Spacer(modifier = Modifier.height(16.dp))
-    Legend(
-        stringResource(id = R.string.event_creation_screen_parking),
-        Icons.Rounded.DirectionsCar,
-        "parking_title")
-    OutlinedTextField(
-        value = parkingText,
-        onValueChange = {
-          parkingText = it
-          try {
-            eventViewModel.updateParkingSpaces(abs(parkingText.toInt()))
-          } catch (_: Exception) {
-            eventViewModel.updateParkingSpaces(0)
-          }
-        },
-        label = { Text(stringResource(id = R.string.event_creation_screen_number_parking)) },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-        modifier = Modifier.fillMaxWidth().testTag("n_parking"))
+  Column(
+      modifier = Modifier.padding(16.dp).fillMaxHeight(), verticalArrangement = Arrangement.Top) {
+        Legend(
+            stringResource(id = R.string.event_creation_screen_logistics),
+            Icons.Rounded.Layers,
+            "logistics_title")
+        Spacer(modifier = Modifier.height(16.dp))
+        Legend(
+            stringResource(id = R.string.event_creation_screen_parking),
+            Icons.Rounded.DirectionsCar,
+            "parking_title")
+        OutlinedTextField(
+            value = parkingText,
+            onValueChange = {
+              parkingText = it
+              try {
+                eventViewModel.updateParkingSpaces(abs(parkingText.toInt()))
+              } catch (_: Exception) {
+                eventViewModel.updateParkingSpaces(0)
+              }
+            },
+            label = { Text(stringResource(id = R.string.event_creation_screen_number_parking)) },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth().testTag("n_parking"))
 
-    Spacer(modifier = Modifier.height(16.dp))
-    Legend(
-        stringResource(id = R.string.event_creation_screen_beds), Icons.Rounded.Bed, "beds_title")
-    OutlinedTextField(
-        value = bedsText,
-        onValueChange = {
-          bedsText = it
-          try {
-            eventViewModel.updateBeds(abs(bedsText.toInt()))
-          } catch (_: Exception) {
-            eventViewModel.updateBeds(0)
-          }
-        },
-        label = { Text(stringResource(id = R.string.event_creation_screen_number_beds)) },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-        modifier = Modifier.fillMaxWidth().testTag("n_beds"))
-  }
+        Spacer(modifier = Modifier.height(16.dp))
+        Legend(
+            stringResource(id = R.string.event_creation_screen_beds),
+            Icons.Rounded.Bed,
+            "beds_title")
+        OutlinedTextField(
+            value = bedsText,
+            onValueChange = {
+              bedsText = it
+              try {
+                eventViewModel.updateBeds(abs(bedsText.toInt()))
+              } catch (_: Exception) {
+                eventViewModel.updateBeds(0)
+              }
+            },
+            label = { Text(stringResource(id = R.string.event_creation_screen_number_beds)) },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth().testTag("n_beds"))
+      }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/ChooseSocialsPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/ChooseSocialsPanel.kt
@@ -25,20 +25,21 @@ fun ChooseSocialsPanel(eventViewModel: EventViewModel) {
         uiState.socialMediaLinks.mapValues { mutableStateOf(it.value.platformName) }
       }
 
-  Column(modifier = Modifier.padding(16.dp)) {
-    Text(
-        stringResource(id = R.string.links_to_social_media),
-        style = ChimpagneTypography.headlineSmall,
-        modifier = Modifier.testTag("social_media_title"))
-    Spacer(modifier = Modifier.height(16.dp))
+  Column(
+      modifier = Modifier.padding(16.dp).fillMaxHeight(), verticalArrangement = Arrangement.Top) {
+        Text(
+            stringResource(id = R.string.links_to_social_media),
+            style = ChimpagneTypography.headlineSmall,
+            modifier = Modifier.testTag("social_media_title"))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    for ((platform) in socialMediaStates) {
-      SocialMediaTextField(
-          socialMedia = uiState.socialMediaLinks[platform]!!,
-          updateSocialMediaLink = { eventViewModel.updateSocialMediaLink(it) })
-      Spacer(modifier = Modifier.height(16.dp))
-    }
-  }
+        for ((platform) in socialMediaStates) {
+          SocialMediaTextField(
+              socialMedia = uiState.socialMediaLinks[platform]!!,
+              updateSocialMediaLink = { eventViewModel.updateSocialMediaLink(it) })
+          Spacer(modifier = Modifier.height(16.dp))
+        }
+      }
 }
 
 @Composable

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -59,14 +59,17 @@ fun EventCreationScreen(
               }
             })
       }) { innerPadding ->
-        HorizontalPager(state = pagerState, modifier = Modifier.padding(innerPadding)) { page ->
-          when (page) {
-            0 -> FirstPanel(eventViewModel)
-            1 -> TagsAndPubPanel(eventViewModel)
-            2 -> SuppliesPanel(eventViewModel)
-            3 -> AdvancedLogisticsPanel(eventViewModel)
-            4 -> ChooseSocialsPanel(eventViewModel)
-          }
-        }
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.padding(innerPadding),
+            beyondBoundsPageCount = 4) { page ->
+              when (page) {
+                0 -> FirstPanel(eventViewModel)
+                1 -> TagsAndPubPanel(eventViewModel)
+                2 -> SuppliesPanel(eventViewModel)
+                3 -> AdvancedLogisticsPanel(eventViewModel)
+                4 -> ChooseSocialsPanel(eventViewModel)
+              }
+            }
       }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -43,12 +43,16 @@ fun EventCreationScreen(
             lastButtonText = stringResource(id = R.string.event_creation_screen_create_event),
             lastButtonOnClick = {
               if (!uiState.loading) {
-                Toast.makeText(
-                        context,
-                        context.getString(R.string.event_creation_screen_toast_creating),
-                        Toast.LENGTH_SHORT)
-                    .show()
                 eventViewModel.createTheEvent(
+                    onInvalidInputs = {
+                      var translatedString = context.getString(R.string.title_should_not_be_empty)
+                      if (it == "Invalid dates") {
+                        translatedString = context.getString(R.string.invalid_dates)
+                        println("INVALID DATE")
+                      }
+
+                      Toast.makeText(context, translatedString, Toast.LENGTH_SHORT).show()
+                    },
                     onSuccess = {
                       Toast.makeText(
                               context,

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -46,11 +46,8 @@ fun EventCreationScreen(
                 eventViewModel.createTheEvent(
                     onInvalidInputs = {
                       var translatedString = context.getString(R.string.title_should_not_be_empty)
-                      if (it == "Invalid dates") {
-                        translatedString = context.getString(R.string.invalid_dates)
-                        println("INVALID DATE")
-                      }
-
+                      if (it == "Invalid dates")
+                          translatedString = context.getString(R.string.invalid_dates)
                       Toast.makeText(context, translatedString, Toast.LENGTH_SHORT).show()
                     },
                     onSuccess = {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -30,6 +30,11 @@ fun EventCreationScreen(
   val pagerState = rememberPagerState(initialPage = initialPage) { 5 }
   val context = LocalContext.current
   val uiState by eventViewModel.uiState.collectAsState()
+
+  fun showToast(message: String) {
+    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+  }
+
   Scaffold(
       topBar = {
         PanelTopBar(
@@ -48,14 +53,10 @@ fun EventCreationScreen(
                       var translatedString = context.getString(R.string.title_should_not_be_empty)
                       if (it == "Invalid dates")
                           translatedString = context.getString(R.string.invalid_dates)
-                      Toast.makeText(context, translatedString, Toast.LENGTH_SHORT).show()
+                      showToast(translatedString)
                     },
                     onSuccess = {
-                      Toast.makeText(
-                              context,
-                              context.getString(R.string.event_creation_screen_toast_finish),
-                              Toast.LENGTH_SHORT)
-                          .show()
+                      showToast(context.getString(R.string.event_creation_screen_toast_finish))
                       navObject.goBack()
                     })
               }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -50,10 +50,7 @@ fun EventCreationScreen(
               if (!uiState.loading) {
                 eventViewModel.createTheEvent(
                     onInvalidInputs = {
-                      var translatedString = context.getString(R.string.title_should_not_be_empty)
-                      if (it == "Invalid dates")
-                          translatedString = context.getString(R.string.invalid_dates)
-                      showToast(translatedString)
+                      showToast(EventViewModel.eventInputValidityToString(it, context))
                     },
                     onSuccess = {
                       showToast(context.getString(R.string.event_creation_screen_toast_finish))

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/PanelBars.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/PanelBars.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material.icons.Icons
@@ -24,6 +25,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import kotlinx.coroutines.launch
@@ -41,6 +43,13 @@ fun PanelTopBar(navObject: NavigationActions, title: String, modifier: Modifier 
       })
 }
 
+@Composable
+fun PanelBottomBarButtonText(text: String) {
+  Text(
+      text = text.uppercase(), fontSize = 20.sp // Adjust the size as needed
+      )
+}
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun PanelBottomBar(
@@ -52,30 +61,34 @@ fun PanelBottomBar(
   // throughout the panels
   val coroutineScope = rememberCoroutineScope()
 
-  Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-    if (pagerState.currentPage > 0) {
-      Button(
-          onClick = {
-            coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) }
-          },
-          modifier = Modifier.testTag("previous_button")) {
-            Text(stringResource(id = R.string.event_creation_screen_previous))
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(24.dp),
+      horizontalArrangement = Arrangement.SpaceBetween) {
+        if (pagerState.currentPage > 0) {
+          Button(
+              onClick = {
+                coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) }
+              },
+              modifier = Modifier.testTag("previous_button")) {
+                PanelBottomBarButtonText(
+                    text = stringResource(id = R.string.event_creation_screen_previous))
+              }
+        } else {
+          Spacer(modifier = Modifier.width(ButtonDefaults.MinWidth))
+        }
+        if (pagerState.currentPage < pagerState.pageCount - 1) {
+          Button(
+              onClick = {
+                coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
+              },
+              modifier = Modifier.testTag("next_button")) {
+                PanelBottomBarButtonText(
+                    text = stringResource(id = R.string.event_creation_screen_next))
+              }
+        } else {
+          Button(onClick = lastButtonOnClick, modifier = Modifier.testTag("last_button")) {
+            PanelBottomBarButtonText(text = lastButtonText)
           }
-    } else {
-      Spacer(modifier = Modifier.width(ButtonDefaults.MinWidth))
-    }
-    if (pagerState.currentPage < pagerState.pageCount - 1) {
-      Button(
-          onClick = {
-            coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
-          },
-          modifier = Modifier.testTag("next_button")) {
-            Text(stringResource(id = R.string.event_creation_screen_next))
-          }
-    } else {
-      Button(onClick = lastButtonOnClick, modifier = Modifier.testTag("last_button")) {
-        Text(lastButtonText)
+        }
       }
-    }
-  }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/SuppliesPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/SuppliesPanel.kt
@@ -1,15 +1,17 @@
 package com.monkeyteam.chimpagne.ui.event
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Inventory2
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
@@ -26,6 +28,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.ui.components.IconTextButton
 import com.monkeyteam.chimpagne.ui.components.Legend
 import com.monkeyteam.chimpagne.ui.event.details.supplies.EditSupplyDialog
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
@@ -35,57 +38,60 @@ import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 fun SuppliesPanel(eventViewModel: EventViewModel) {
   val uiState by eventViewModel.uiState.collectAsState()
 
-  Column(modifier = Modifier.padding(16.dp)) {
-    Legend(
-        stringResource(id = R.string.event_creation_screen_supplies),
-        Icons.Rounded.Inventory2,
-        "supplies_title")
-    Spacer(modifier = Modifier.height(16.dp))
+  Column(
+      modifier = Modifier.fillMaxHeight().padding(16.dp), verticalArrangement = Arrangement.Top) {
+        Legend(
+            stringResource(id = R.string.event_creation_screen_supplies),
+            Icons.Rounded.Inventory2,
+            "supplies_title")
+        Spacer(modifier = Modifier.height(16.dp))
 
-    val showAddDialog = remember { mutableStateOf(false) }
-    Button(
-        onClick = { showAddDialog.value = true },
-        modifier = Modifier.testTag("add_supplies_button")) {
-          Text(stringResource(id = R.string.event_creation_screen_add_supplies))
+        val showAddDialog = remember { mutableStateOf(false) }
+
+        IconTextButton(
+            text = stringResource(id = R.string.event_creation_screen_add_supplies),
+            icon = Icons.Rounded.Add,
+            onClick = { showAddDialog.value = true },
+            modifier = Modifier.testTag("add_supplies_button"))
+
+        if (showAddDialog.value) {
+
+          EditSupplyDialog(
+              onDismissRequest = { showAddDialog.value = false },
+              onSave = eventViewModel::addSupply)
         }
 
-    if (showAddDialog.value) {
+        Spacer(modifier = Modifier.height(16.dp))
 
-      EditSupplyDialog(
-          onDismissRequest = { showAddDialog.value = false }, onSave = eventViewModel::addSupply)
-    }
-
-    Spacer(modifier = Modifier.height(16.dp))
-
-    LazyColumn {
-      items(uiState.supplies.values.toList()) { item ->
-        ListItem(
-            headlineContent = {
-              Text(
-                  text = item.description,
-              )
-            },
-            supportingContent = {
-              Text(text = item.quantity.toString() + " " + item.unit, color = Color.Gray)
-            },
-            trailingContent = {
-              IconButton(
-                  onClick = { eventViewModel.removeSupply(item.id) },
-                  modifier = Modifier.testTag(item.description),
-                  content = {
-                    Icon(
-                        active = true,
-                        activeContent = {
-                          androidx.compose.material3.Icon(
-                              imageVector = Icons.Default.Cancel, contentDescription = "Delete")
-                        },
-                        inactiveContent = {
-                          androidx.compose.material3.Icon(
-                              imageVector = Icons.Default.Cancel, contentDescription = "Delete")
-                        })
-                  })
-            })
+        LazyColumn {
+          items(uiState.supplies.values.toList()) { item ->
+            ListItem(
+                headlineContent = {
+                  Text(
+                      text = item.description,
+                  )
+                },
+                supportingContent = {
+                  Text(text = item.quantity.toString() + " " + item.unit, color = Color.Gray)
+                },
+                trailingContent = {
+                  IconButton(
+                      onClick = { eventViewModel.removeSupply(item.id) },
+                      modifier = Modifier.testTag(item.description),
+                      content = {
+                        Icon(
+                            active = true,
+                            activeContent = {
+                              androidx.compose.material3.Icon(
+                                  imageVector = Icons.Default.Cancel, contentDescription = "Delete")
+                            },
+                            inactiveContent = {
+                              androidx.compose.material3.Icon(
+                                  imageVector = Icons.Default.Cancel, contentDescription = "Delete")
+                            })
+                      })
+                })
+          }
+        }
       }
-    }
-  }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/TagsAndPubPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/TagsAndPubPanel.kt
@@ -1,8 +1,10 @@
 package com.monkeyteam.chimpagne.ui.event
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -33,32 +35,35 @@ fun TagsAndPubPanel(eventViewModel: EventViewModel) {
 
   var tagFieldActive by remember { mutableStateOf(true) }
 
-  Column(modifier = Modifier.padding(16.dp)) {
-    Legend(
-        stringResource(id = R.string.event_creation_screen_tags_legend), Icons.Rounded.Tag, "Tags")
+  Column(
+      modifier = Modifier.fillMaxHeight().padding(16.dp), verticalArrangement = Arrangement.Top) {
+        Legend(
+            stringResource(id = R.string.event_creation_screen_tags_legend),
+            Icons.Rounded.Tag,
+            "Tags")
 
-    TagField(
-        uiState.tags,
-        eventViewModel::updateEventTags,
-        { tagFieldActive = it },
-        Modifier.fillMaxWidth().testTag("tag_field"))
+        TagField(
+            uiState.tags,
+            eventViewModel::updateEventTags,
+            { tagFieldActive = it },
+            Modifier.fillMaxWidth().testTag("tag_field"))
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    Legend(
-        stringResource(id = R.string.event_creation_screen_public_legend),
-        Icons.Rounded.Public,
-        "Public")
+        Legend(
+            stringResource(id = R.string.event_creation_screen_public_legend),
+            Icons.Rounded.Public,
+            "Public")
 
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      Checkbox(
-          checked = uiState.public,
-          onCheckedChange = { eventViewModel.updateEventPublicity(!uiState.public) })
-      if (uiState.public)
-          Text(stringResource(id = R.string.event_creation_screen_event_made_public))
-      else Text(stringResource(id = R.string.event_creation_screen_make_event_public))
-    }
-  }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+          Checkbox(
+              checked = uiState.public,
+              onCheckedChange = { eventViewModel.updateEventPublicity(!uiState.public) })
+          if (uiState.public)
+              Text(stringResource(id = R.string.event_creation_screen_event_made_public))
+          else Text(stringResource(id = R.string.event_creation_screen_make_event_public))
+        }
+      }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -141,7 +141,6 @@ class EventViewModel(
               onSuccess(it)
             },
             {
-              Log.d("CREATE AN EVENT", "Error : ", it)
               _uiState.value = _uiState.value.copy(loading = false)
               onFailure(it)
             })

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -1,9 +1,11 @@
 package com.monkeyteam.chimpagne.viewmodels
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.database.ChimpagneAccountUID
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.database.ChimpagnePoll
@@ -23,6 +25,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
+enum class EventInputValidity {
+  INVALID_TITLE,
+  INVALID_DATES
+}
+
 class EventViewModel(
     private var eventID: String? = null,
     database: Database,
@@ -39,6 +46,15 @@ class EventViewModel(
 
   init {
     fetchEvent(onSuccess, onFailure)
+  }
+
+  companion object {
+    fun eventInputValidityToString(e: EventInputValidity, context: Context): String {
+      return when (e) {
+        EventInputValidity.INVALID_TITLE -> context.getString(R.string.title_should_not_be_empty)
+        EventInputValidity.INVALID_DATES -> context.getString(R.string.invalid_dates)
+      }
+    }
   }
 
   /* THIS MUST BE CALLED IN MAIN ACTIVITY ON TRANSITION TO THE SCREEN THAT USES THE VIEW MODEL */
@@ -117,7 +133,7 @@ class EventViewModel(
 
   fun createTheEvent(
       onSuccess: (id: String) -> Unit = {},
-      onInvalidInputs: (String) -> Unit = {},
+      onInvalidInputs: (EventInputValidity) -> Unit = {},
       onFailure: (Exception) -> Unit = {}
   ) {
     if (_uiState.value.title.isEmpty() ||
@@ -125,9 +141,9 @@ class EventViewModel(
         uiState.value.startsAtCalendarDate.equals(_uiState.value.endsAtCalendarDate)) {
 
       if (_uiState.value.title.isEmpty()) {
-        onInvalidInputs("Title should not be empty")
+        onInvalidInputs(EventInputValidity.INVALID_TITLE)
       } else {
-        onInvalidInputs("Invalid dates")
+        onInvalidInputs(EventInputValidity.INVALID_DATES)
       }
     } else {
       _uiState.value = _uiState.value.copy(loading = true)

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -110,22 +110,38 @@ class EventViewModel(
         socialMediaLinks = convertSMToSMLinks(_uiState.value.socialMediaLinks))
   }
 
-  fun createTheEvent(onSuccess: (id: String) -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
+  fun createTheEvent(
+      onSuccess: (id: String) -> Unit = {},
+      onInvalidInputs: (String) -> Unit = {},
+      onFailure: (Exception) -> Unit = {}
+  ) {
     _uiState.value = _uiState.value.copy(loading = true)
     viewModelScope.launch {
-      eventManager.createEvent(
-          buildChimpagneEvent(),
-          {
-            _uiState.value = _uiState.value.copy(id = it)
-            eventID = _uiState.value.id
-            _uiState.value = _uiState.value.copy(loading = false)
-            onSuccess(it)
-          },
-          {
-            Log.d("CREATE AN EVENT", "Error : ", it)
-            _uiState.value = _uiState.value.copy(loading = false)
-            onFailure(it)
-          })
+      if (_uiState.value.title.isEmpty() ||
+          _uiState.value.startsAtCalendarDate.after(_uiState.value.endsAtCalendarDate) ||
+          uiState.value.startsAtCalendarDate.equals(_uiState.value.endsAtCalendarDate)) {
+
+        if (_uiState.value.title.isEmpty()) {
+          onInvalidInputs("Title should not be empty")
+        } else {
+          onInvalidInputs("Invalid dates")
+        }
+      } else {
+
+        eventManager.createEvent(
+            buildChimpagneEvent(),
+            {
+              _uiState.value = _uiState.value.copy(id = it)
+              eventID = _uiState.value.id
+              _uiState.value = _uiState.value.copy(loading = false)
+              onSuccess(it)
+            },
+            {
+              Log.d("CREATE AN EVENT", "Error : ", it)
+              _uiState.value = _uiState.value.copy(loading = false)
+              onFailure(it)
+            })
+      }
     }
   }
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -499,8 +499,10 @@ class EventViewModel(
       val tags: List<String> = emptyList(),
       val guests: Map<String, Boolean> = emptyMap(),
       val staffs: Map<String, Boolean> = emptyMap(),
-      val startsAtCalendarDate: Calendar = Calendar.getInstance(),
-      val endsAtCalendarDate: Calendar = Calendar.getInstance(),
+      val startsAtCalendarDate: Calendar =
+          Calendar.getInstance().apply { add(Calendar.HOUR_OF_DAY, 1) },
+      val endsAtCalendarDate: Calendar =
+          Calendar.getInstance().apply { add(Calendar.HOUR_OF_DAY, 2) },
       val supplies: Map<ChimpagneSupplyId, ChimpagneSupply> = mapOf(),
       val parkingSpaces: Int = 0,
       val beds: Int = 0,

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -120,19 +120,18 @@ class EventViewModel(
       onInvalidInputs: (String) -> Unit = {},
       onFailure: (Exception) -> Unit = {}
   ) {
-    _uiState.value = _uiState.value.copy(loading = true)
-    viewModelScope.launch {
-      if (_uiState.value.title.isEmpty() ||
-          _uiState.value.startsAtCalendarDate.after(_uiState.value.endsAtCalendarDate) ||
-          uiState.value.startsAtCalendarDate.equals(_uiState.value.endsAtCalendarDate)) {
+    if (_uiState.value.title.isEmpty() ||
+        _uiState.value.startsAtCalendarDate.after(_uiState.value.endsAtCalendarDate) ||
+        uiState.value.startsAtCalendarDate.equals(_uiState.value.endsAtCalendarDate)) {
 
-        if (_uiState.value.title.isEmpty()) {
-          onInvalidInputs("Title should not be empty")
-        } else {
-          onInvalidInputs("Invalid dates")
-        }
+      if (_uiState.value.title.isEmpty()) {
+        onInvalidInputs("Title should not be empty")
       } else {
-
+        onInvalidInputs("Invalid dates")
+      }
+    } else {
+      _uiState.value = _uiState.value.copy(loading = true)
+      viewModelScope.launch {
         eventManager.createEvent(
             buildChimpagneEvent(),
             {

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/FindEventsViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/FindEventsViewModel.kt
@@ -72,7 +72,7 @@ class FindEventsViewModel(database: Database) : ViewModel() {
   fun fetchAroundLocation(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     eventManager.getAllEventsByFilterAroundLocation(
         _uiState.value.selectedLocation!!,
-        9999999999.0,
+        Double.MAX_VALUE,
         {
           _uiState.value = _uiState.value.copy(events = it.associateBy { event -> event.id })
           if (it.isEmpty()) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -27,7 +27,7 @@
     <string name="event_creation_screen_event_made_public">Cet événement a été rendu publique !</string>
     <string name="event_creation_screen_make_event_public">Rendre cet événement publique</string>
     <string name="event_creation_screen_public_legend">Visibilité De l\'événement</string>
-    <string name="event_creation_screen_logistics">Logistique avancée</string>
+    <string name="event_creation_screen_logistics">Aménagements</string>
     <string name="event_creation_screen_parking">Parking</string>
     <string name="event_creation_screen_number_parking">Nombre de places de parque</string>
     <string name="event_creation_screen_number_beds">Nombre de lits</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -140,5 +140,7 @@
     <string name="public_string">Public</string>
     <string name="private_string">Privé</string>
 
+    <string name="title_should_not_be_empty">Le titre de l\'événement ne peut être vide</string>
+    <string name="invalid_dates">Dates invalides</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="event_creation_screen_event_made_public">This event has been made public !</string>
     <string name="event_creation_screen_make_event_public">Make this event public</string>
     <string name="event_creation_screen_public_legend">Event Publicity</string>
-    <string name="event_creation_screen_logistics">Advanced Logistics</string>
+    <string name="event_creation_screen_logistics">Accommodations</string>
     <string name="event_creation_screen_parking">Parking</string>
     <string name="event_creation_screen_number_parking">Number of parking places</string>
     <string name="event_creation_screen_number_beds">Number of beds</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,4 +145,7 @@
     <string name="acount_creation_failed_toast">Account creation failed</string>
     <string name="public_string">Public</string>
     <string name="private_string">Private</string>
+
+    <string name="title_should_not_be_empty">The event title should not be empty</string>
+    <string name="invalid_dates">Invalid dates</string>
 </resources>


### PR DESCRIPTION
Bug fixes:
- No negative values for the number of beds and parking spaces
- Checks if the title is empty and displays a toast if necessary
- Checks if the start and end date are equals, or if the start is later than the end, displays a toast if necessary
See the related issue : https://github.com/Chimpagne/ChimpagneApp/issues/192

This required some changes to the viewmodel for event creation.

"Advanced logistics" has been renammed to "Accomodations"