### PR TITLE
Fix supplies in main

### DIFF
--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
@@ -452,11 +452,8 @@ fun ViewDetailEventScreen(
                                         stringResource(
                                             id = R.string.event_details_screen_supplies_button),
                                     onClick = {
-                                      Toast.makeText(
-                                              context,
-                                              "This function will be implemented in a future version",
-                                              Toast.LENGTH_SHORT)
-                                          .show()
+                                            navObject.navigateTo(
+                                                Route.SUPPLIES_SCREEN + "/" + uiState.id)
                                     },
                                     testTag = "supplies"),
                                 IconInfo(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/ViewDetailEventScreen.kt
@@ -452,8 +452,7 @@ fun ViewDetailEventScreen(
                                         stringResource(
                                             id = R.string.event_details_screen_supplies_button),
                                     onClick = {
-                                            navObject.navigateTo(
-                                                Route.SUPPLIES_SCREEN + "/" + uiState.id)
+                                      navObject.navigateTo(Route.SUPPLIES_SCREEN + "/" + uiState.id)
                                     },
                                     testTag = "supplies"),
                                 IconInfo(


### PR DESCRIPTION
This PR is meant to fix a merge that took out the navigate part of view detail of event page to the supplies page.
It was probably overlooked in the reviews since a lot of deletions happened in the file in [this PR](https://github.com/Chimpagne/ChimpagneApp/pull/187) .