### PR TITLE
New UI for the detail screen Sheet (on the map)

### DIFF
--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/DetailScreenSheet.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/DetailScreenSheet.kt
@@ -2,13 +2,23 @@ package com.monkeyteam.chimpagne.ui
 
 import android.content.Context
 import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -17,14 +27,22 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
+import com.monkeyteam.chimpagne.model.utils.buildTimestamp
 import com.monkeyteam.chimpagne.model.utils.createCalendarIntent
+import com.monkeyteam.chimpagne.model.utils.simpleDateFormat
+import com.monkeyteam.chimpagne.model.utils.simpleTimeFormat
 import com.monkeyteam.chimpagne.ui.components.SimpleTagChip
 import com.monkeyteam.chimpagne.ui.components.popUpCalendar
+import com.monkeyteam.chimpagne.ui.theme.ChimpagneFontFamily
 import com.monkeyteam.chimpagne.ui.theme.ChimpagneTypography
 
 @Composable
@@ -45,34 +63,94 @@ fun DetailScreenSheet(
           Text(
               text = event.title,
               style = ChimpagneTypography.headlineMedium,
-              modifier = Modifier.padding(bottom = 8.dp))
-
-          Text(
-              text = event.startsAt().time.toString(),
-              style = ChimpagneTypography.bodyMedium,
-              modifier = Modifier.padding(bottom = 8.dp))
-
-          Text(
-              text = event.endsAt().time.toString(),
-              style = ChimpagneTypography.bodyMedium,
-              modifier = Modifier.padding(bottom = 8.dp))
-
-          Text(
-              text = event.description,
-              style = ChimpagneTypography.bodySmall,
-              modifier = Modifier.padding(bottom = 8.dp))
-
+              modifier = Modifier.padding(bottom = 16.dp))
           Row(
-              modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-              horizontalArrangement = Arrangement.SpaceEvenly) {
-                event.tags.forEach { tag -> SimpleTagChip(tag) }
+              modifier = Modifier.fillMaxWidth().testTag("event date"),
+              horizontalArrangement = Arrangement.SpaceBetween) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                  Text(
+                      text = stringResource(id = R.string.date_tools_from),
+                      fontFamily = ChimpagneFontFamily,
+                      fontSize = 16.sp,
+                      color = Color.Gray)
+                  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = simpleDateFormat(buildTimestamp(event.startsAt())),
+                        fontFamily = ChimpagneFontFamily,
+                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Bold)
+                    Text(
+                        text = simpleTimeFormat(buildTimestamp(event.startsAt())),
+                        fontFamily = ChimpagneFontFamily,
+                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Bold)
+                  }
+                }
+                Button(
+                    onClick = enhancedOnJoinClick,
+                    modifier = Modifier.testTag("join_button").padding(vertical = 4.dp)) {
+                      Text(stringResource(id = R.string.find_event_join_event_button_text))
+                    }
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                  Text(
+                      text = stringResource(id = R.string.date_tools_until),
+                      fontFamily = ChimpagneFontFamily,
+                      fontSize = 16.sp,
+                      color = Color.Gray)
+                  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = simpleDateFormat(buildTimestamp(event.endsAt())),
+                        fontFamily = ChimpagneFontFamily,
+                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Bold)
+                    Text(
+                        text = simpleTimeFormat(buildTimestamp(event.endsAt())),
+                        fontFamily = ChimpagneFontFamily,
+                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Bold)
+                  }
+                }
               }
 
-          Button(
-              onClick = enhancedOnJoinClick,
-              modifier = Modifier.align(Alignment.CenterHorizontally).testTag("join_button")) {
-                Text(stringResource(id = R.string.find_event_join_event_button_text))
+          var expandedDescription by remember { mutableStateOf(false) }
+          val maxLines = if (expandedDescription) Int.MAX_VALUE else 3
+          Row(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .testTag("description")
+                      .clickable { expandedDescription = !expandedDescription }
+                      .padding(horizontal = 16.dp, vertical = 8.dp)) {
+                Text(
+                    text = event.description,
+                    fontSize = 16.sp,
+                    fontFamily = ChimpagneFontFamily,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    maxLines = maxLines,
+                    modifier = Modifier.weight(1f))
+                Icon(
+                    imageVector =
+                        if (expandedDescription) Icons.Filled.ArrowDropUp
+                        else Icons.Filled.ArrowDropDown,
+                    contentDescription = if (expandedDescription) "Collapse" else "Expand",
+                    tint = MaterialTheme.colorScheme.primary)
               }
+
+          Row(modifier = Modifier.horizontalScroll(rememberScrollState()).testTag("tag list")) {
+            event.tags.forEach { tag ->
+              Box(
+                  modifier =
+                      Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+                          .clip(RoundedCornerShape(50))
+                          .background(MaterialTheme.colorScheme.primaryContainer)
+                          .padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    SimpleTagChip(tag)
+                  }
+            }
+          }
         }
     if (showDialog && context != null) {
       popUpCalendar(


### PR DESCRIPTION
This PR enhances the UI of the detailed event screen Sheet that appears when clicking on an event on the map. For specific UI details, please refer to the Figma design. The updates include:

1. Added a description field that expands for longer texts.
2. Improved the visual presentation everything (Date, time, tags).

In a subsequent PR, a "See Details" button will be added. This button will allow users who have not joined the event to access the event details screen and view available features. Note that the detailed event screen will differ for users who have not joined, such as not displaying the "Leave Event" button.

![image](https://github.com/Chimpagne/ChimpagneApp/assets/60262512/da702440-a354-45e8-9757-7c572ec4ddd5)
![image](https://github.com/Chimpagne/ChimpagneApp/assets/60262512/2835353d-114b-45f4-b883-04f60133b44e)
