### PR TITLE
Android Share sheet

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/event/EventCreationScreenTest.kt
@@ -198,6 +198,8 @@ class EventCreationScreenTest {
     composeTestRule.onNodeWithTag("n_beds").performTextInput(valueBed)
     composeTestRule.onNodeWithTag("last_button").assertDoesNotExist()
     composeTestRule.onNodeWithTag("next_button").performClick()
+
+    composeTestRule.onNodeWithTag("EventPicture").assertExists().performClick()
   }
 
   @Test

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEvent.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEvent.kt
@@ -1,6 +1,5 @@
 package com.monkeyteam.chimpagne.model.database
 
-import android.net.Uri
 import com.google.firebase.Timestamp
 import com.monkeyteam.chimpagne.model.location.Location
 import com.monkeyteam.chimpagne.model.utils.buildCalendar
@@ -26,7 +25,7 @@ data class ChimpagneEvent(
     val supplies: Map<ChimpagneSupplyId, ChimpagneSupply> = mapOf(),
     val parkingSpaces: Int = 0,
     val beds: Int = 0,
-    val imageUri: Uri? = null,
+    val imageUri: String? = null,
     val socialMediaLinks: Map<String, String> =
         SupportedSocialMedia.associateBy { it.platformName }.mapValues { it.value.chosenGroupUrl },
     val polls: Map<ChimpagnePollId, ChimpagnePoll> = emptyMap()
@@ -74,7 +73,7 @@ data class ChimpagneEvent(
       supplies: Map<ChimpagneSupplyId, ChimpagneSupply> = mapOf(),
       parkingSpaces: Int,
       beds: Int,
-      imageUri: Uri?,
+      imageUri: String?,
       socialMediaLinks: Map<String, String>,
       polls: Map<ChimpagnePollId, ChimpagnePoll>
   ) : this(

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEvent.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEvent.kt
@@ -1,5 +1,6 @@
 package com.monkeyteam.chimpagne.model.database
 
+import android.net.Uri
 import com.google.firebase.Timestamp
 import com.monkeyteam.chimpagne.model.location.Location
 import com.monkeyteam.chimpagne.model.utils.buildCalendar
@@ -25,7 +26,7 @@ data class ChimpagneEvent(
     val supplies: Map<ChimpagneSupplyId, ChimpagneSupply> = mapOf(),
     val parkingSpaces: Int = 0,
     val beds: Int = 0,
-    val imageUrl: String = "", // TODO: Add image
+    val imageUri: Uri? = null,
     val socialMediaLinks: Map<String, String> =
         SupportedSocialMedia.associateBy { it.platformName }.mapValues { it.value.chosenGroupUrl },
     val polls: Map<ChimpagnePollId, ChimpagnePoll> = emptyMap()
@@ -73,7 +74,7 @@ data class ChimpagneEvent(
       supplies: Map<ChimpagneSupplyId, ChimpagneSupply> = mapOf(),
       parkingSpaces: Int,
       beds: Int,
-      imageUrl: String,
+      imageUri: Uri?,
       socialMediaLinks: Map<String, String>,
       polls: Map<ChimpagnePollId, ChimpagnePoll>
   ) : this(
@@ -91,7 +92,7 @@ data class ChimpagneEvent(
       supplies,
       parkingSpaces,
       beds,
-      imageUrl,
+      imageUri,
       socialMediaLinks,
       polls)
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
@@ -1,6 +1,5 @@
 package com.monkeyteam.chimpagne.model.database
 
-import android.util.Log
 import androidx.core.net.toUri
 import com.firebase.geofire.GeoFireUtils
 import com.firebase.geofire.GeoLocation
@@ -98,7 +97,6 @@ class ChimpagneEventManager(
         .putFile(eventPictureUri.toUri())
         .addOnSuccessListener {
           imageRef.downloadUrl.addOnSuccessListener { downloadUrl ->
-            Log.d("ChimpagneAccountManager", "Uploaded image to: $downloadUrl")
             onSuccess(downloadUrl.toString())
           }
         }
@@ -117,7 +115,6 @@ class ChimpagneEventManager(
     }
     val eventId = events.document().id
     if (eventPictureUri != null) {
-      Log.d("ChimpagneEventManager", "Uploading event picture with uri: $eventPictureUri")
       uploadEventPicture(
           event.copy(id = eventId),
           {
@@ -154,7 +151,7 @@ class ChimpagneEventManager(
       return
     }
 
-    if (eventPictureUri != null) {
+    if (eventPictureUri != null && event.imageUri != eventPictureUri) {
       uploadEventPicture(
           event,
           {

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
@@ -1,6 +1,5 @@
 package com.monkeyteam.chimpagne.model.database
 
-import android.net.Uri
 import android.util.Log
 import androidx.core.net.toUri
 import com.firebase.geofire.GeoFireUtils
@@ -73,21 +72,9 @@ class ChimpagneEventManager(
         .addOnFailureListener { onFailure(it) }
   }
 
-  fun fetchEventPictureUri(uid: String, onSuccess: (Uri?) -> Unit) {
-    if (uid.isEmpty()) {
-      onSuccess(null)
-    } else {
-      eventPictures
-          .child(uid)
-          .downloadUrl
-          .addOnSuccessListener { downloadedURI -> onSuccess(downloadedURI) }
-          .addOnFailureListener { onSuccess(null) }
-    }
-  }
-
   fun getEventById(
       id: String,
-      onSuccess: (ChimpagneEvent?, String?) -> Unit,
+      onSuccess: (ChimpagneEvent?) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
     events
@@ -95,12 +82,7 @@ class ChimpagneEventManager(
         .get()
         .addOnSuccessListener { account ->
           val event = account.toObject<ChimpagneEvent>()
-          if (event != null) {
-            fetchEventPictureUri(id) { uri -> onSuccess(event, uri.toString()) }
-            Log.d("ChimpagneAccountManager", "Fetched event: $event")
-          } else {
-            onSuccess(null, null)
-          }
+          onSuccess(event)
         }
         .addOnFailureListener { onFailure(it) }
   }
@@ -237,12 +219,6 @@ class ChimpagneEventManager(
               events.add(event)
             }
           }
-          /*val eventsWithPictures: MutableList<ChimpagneEvent> = ArrayList()
-          for (event in events) {
-            fetchEventPictureUri(event.id) { uri ->
-              eventsWithPictures.add(event.copy(imageUri = uri.toString()))
-            }
-          }*/
           onSuccess(events)
         }
         .addOnFailureListener { onFailure(it) }

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
@@ -140,7 +140,7 @@ class ChimpagneEventManager(
           event.copy(id = eventId),
           {
             updateEvent(
-                event.copy(id = eventId),
+                event.copy(id = eventId, imageUri = it),
                 {
                   database.accountManager.joinEvent(
                       eventId, ChimpagneRole.OWNER, { onSuccess(eventId) }, { onFailure(it) })
@@ -176,9 +176,10 @@ class ChimpagneEventManager(
       uploadEventPicture(
           event,
           {
+            val eventWithPicture = event.copy(imageUri = it)
             events
                 .document(event.id)
-                .set(event)
+                .set(eventWithPicture)
                 .addOnSuccessListener { onSuccess() }
                 .addOnFailureListener { onFailure(it) }
           },

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
@@ -160,18 +160,37 @@ class ChimpagneEventManager(
     }
   }
 
-  fun updateEvent(event: ChimpagneEvent, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+  fun updateEvent(
+      event: ChimpagneEvent,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit,
+      eventPictureUri: String? = null
+  ) {
 
     if (event.id == "") {
       onFailure(Exception("null event id"))
       return
     }
 
-    events
-        .document(event.id)
-        .set(event)
-        .addOnSuccessListener { onSuccess() }
-        .addOnFailureListener { onFailure(it) }
+    if (eventPictureUri != null) {
+      uploadEventPicture(
+          event,
+          {
+            events
+                .document(event.id)
+                .set(event)
+                .addOnSuccessListener { onSuccess() }
+                .addOnFailureListener { onFailure(it) }
+          },
+          { onFailure(it) },
+          eventPictureUri)
+    } else {
+      events
+          .document(event.id)
+          .set(event)
+          .addOnSuccessListener { onSuccess() }
+          .addOnFailureListener { onFailure(it) }
+    }
   }
 
   fun deleteEvent(id: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {

--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/Database.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/Database.kt
@@ -9,8 +9,9 @@ class Database(tables: Tables = TEST_TABLES) {
   private val events = db.collection(tables.EVENTS)
   private val accounts = db.collection(tables.ACCOUNTS)
   private val profilePictures = Firebase.storage.reference.child(tables.PROFILE_PICTURES)
+  private val eventPictures = Firebase.storage.reference.child(tables.EVENT_PICTURES)
 
-  val eventManager = ChimpagneEventManager(this, events)
+  val eventManager = ChimpagneEventManager(this, events, eventPictures)
   val accountManager = ChimpagneAccountManager(this, accounts, profilePictures)
 }
 
@@ -18,16 +19,19 @@ interface Tables {
   val EVENTS: String
   val ACCOUNTS: String
   val PROFILE_PICTURES: String
+  val EVENT_PICTURES: String
 }
 
 object PUBLIC_TABLES : Tables {
   override val EVENTS = "events"
   override val ACCOUNTS = "accounts"
   override val PROFILE_PICTURES = "profilePictures"
+  override val EVENT_PICTURES = "eventPictures"
 }
 
 object TEST_TABLES : Tables {
   override val EVENTS = "testevents"
   override val ACCOUNTS = "testAccounts"
   override val PROFILE_PICTURES = "testProfilePictures"
+  override val EVENT_PICTURES = "testEventPictures"
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/EventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/EventScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -95,6 +96,9 @@ fun EventScreen(
     toast?.cancel()
     toast = Toast.makeText(context, message, Toast.LENGTH_SHORT).apply { show() }
   }
+
+  // Needed, otherwise screen doesnt update instantly after event is edited
+  LaunchedEffect(Unit) { eventViewModel.fetchEvent {} }
 
   val onJoinClick: (ChimpagneEvent) -> Unit = { event ->
     when {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/EventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/EventScreen.kt
@@ -1,5 +1,6 @@
 package com.monkeyteam.chimpagne.ui
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -98,7 +99,7 @@ fun EventScreen(
   }
 
   // Needed, otherwise screen doesnt update instantly after event is edited
-  LaunchedEffect(Unit) { eventViewModel.fetchEvent {} }
+  LaunchedEffect(Unit) { eventViewModel.fetchEvent() }
 
   val onJoinClick: (ChimpagneEvent) -> Unit = { event ->
     when {
@@ -217,7 +218,10 @@ fun EventScreen(
                       .padding(innerPadding)
                       .background(MaterialTheme.colorScheme.background),
               verticalArrangement = Arrangement.Top) {
-                item { ImageCard(uiState.imageUri) }
+                item {
+                  Log.d("EventScreen", "ImageUri: ${uiState}")
+                  ImageCard(uiState.imageUri)
+                }
                 item {
                   Row(
                       modifier =

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/EventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/EventScreen.kt
@@ -213,7 +213,7 @@ fun EventScreen(
                       .padding(innerPadding)
                       .background(MaterialTheme.colorScheme.background),
               verticalArrangement = Arrangement.Top) {
-                item { ImageCard(uiState.imageUrl) }
+                item { ImageCard(uiState.imageUri) }
                 item {
                   Row(
                       modifier =

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/EventCard.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/EventCard.kt
@@ -51,7 +51,7 @@ fun EventCard(event: ChimpagneEvent, modifier: Modifier = Modifier, onClick: () 
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)) {
           Column(modifier = Modifier.fillMaxSize()) {
             Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
-              ImageWithBlackFilterOverlay(event.imageUrl, true)
+              ImageWithBlackFilterOverlay(event.imageUri, true)
               // Adding the status overlay on top of the image
               Row(
                   horizontalArrangement = Arrangement.End,

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/EventCard.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/EventCard.kt
@@ -51,7 +51,7 @@ fun EventCard(event: ChimpagneEvent, modifier: Modifier = Modifier, onClick: () 
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)) {
           Column(modifier = Modifier.fillMaxSize()) {
             Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
-              ImageWithBlackFilterOverlay(event.imageUri, true)
+              ImageLoader(event.imageUri, true)
               // Adding the status overlay on top of the image
               Row(
                   horizontalArrangement = Arrangement.End,

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/EventCard.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/EventCard.kt
@@ -36,7 +36,7 @@ import com.monkeyteam.chimpagne.model.utils.timestampToStringWithDateAndTime
 import com.monkeyteam.chimpagne.ui.theme.ChimpagneTypography
 
 @Composable
-fun EventCard(event: ChimpagneEvent, modifier: Modifier = Modifier, onClick: () -> Unit) {
+fun EventCard(event: ChimpagneEvent, modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
   Box(modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp).fillMaxWidth()) {
     Card(
         modifier =

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/ImageLoader.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/ImageLoader.kt
@@ -1,5 +1,6 @@
 package com.monkeyteam.chimpagne.ui.components
 
+import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -14,9 +15,9 @@ import coil.compose.rememberAsyncImagePainter
 import com.monkeyteam.chimpagne.R
 
 @Composable
-fun ImageWithBlackFilterOverlay(imageString: String = "", overlay: Boolean = false) {
+fun ImageWithBlackFilterOverlay(imageUri: Uri? = null, overlay: Boolean = false) {
   Box(modifier = Modifier.fillMaxWidth()) {
-    if (imageString.isEmpty()) {
+    if (imageUri == null) {
       Image(
           painter = painterResource(id = R.drawable.chimpagne_app_logo),
           contentDescription = "Default Logo",
@@ -24,7 +25,7 @@ fun ImageWithBlackFilterOverlay(imageString: String = "", overlay: Boolean = fal
           modifier = Modifier.fillMaxWidth())
     } else {
       Image(
-          painter = rememberAsyncImagePainter(model = imageString),
+          painter = rememberAsyncImagePainter(model = imageUri),
           contentDescription = "Event Image",
           contentScale = ContentScale.Crop,
           modifier = Modifier.fillMaxSize())

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/ImageLoader.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/ImageLoader.kt
@@ -1,35 +1,35 @@
 package com.monkeyteam.chimpagne.ui.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
-import coil.compose.rememberAsyncImagePainter
+import androidx.compose.ui.platform.LocalContext
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.monkeyteam.chimpagne.R
 
 @Composable
-fun ImageWithBlackFilterOverlay(imageUri: String? = null, overlay: Boolean = false) {
-  Box(modifier = Modifier.fillMaxWidth()) {
-    if (imageUri == null) {
-      Image(
-          painter = painterResource(id = R.drawable.chimpagne_app_logo),
-          contentDescription = "Default Logo",
-          contentScale = ContentScale.FillWidth,
-          modifier = Modifier.fillMaxWidth())
-    } else {
-      Image(
-          painter = rememberAsyncImagePainter(model = imageUri),
-          contentDescription = "Event Image",
-          contentScale = ContentScale.Crop,
-          modifier = Modifier.fillMaxSize())
+fun ImageLoader(imageUri: String? = null, overlay: Boolean = false) {
+  Box(modifier = Modifier.fillMaxSize()) {
+    val context = LocalContext.current
+    val request =
+        ImageRequest.Builder(context)
+            .data(imageUri ?: R.drawable.chimpagne_app_logo)
+            .placeholder(R.drawable.chimpagne_app_logo)
+            .error(R.drawable.chimpagne_app_logo)
+            .build()
+
+    AsyncImage(
+        model = request,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = Modifier.fillMaxSize())
+    if (overlay) {
+      Box(modifier = Modifier.matchParentSize().background(Color.Black.copy(alpha = 0.3f)))
     }
-    if (!overlay) return
-    Box(modifier = Modifier.matchParentSize().background(Color.Black.copy(alpha = 0.3f)))
   }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/ImageLoader.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/ImageLoader.kt
@@ -1,6 +1,5 @@
 package com.monkeyteam.chimpagne.ui.components
 
-import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -15,7 +14,7 @@ import coil.compose.rememberAsyncImagePainter
 import com.monkeyteam.chimpagne.R
 
 @Composable
-fun ImageWithBlackFilterOverlay(imageUri: Uri? = null, overlay: Boolean = false) {
+fun ImageWithBlackFilterOverlay(imageUri: String? = null, overlay: Boolean = false) {
   Box(modifier = Modifier.fillMaxWidth()) {
     if (imageUri == null) {
       Image(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/ImageCard.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/ImageCard.kt
@@ -1,6 +1,5 @@
 package com.monkeyteam.chimpagne.ui.components.eventview
 
-import android.net.Uri
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -14,7 +13,7 @@ import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.ui.components.ImageWithBlackFilterOverlay
 
 @Composable
-fun ImageCard(imageUri: Uri?) {
+fun ImageCard(imageUri: String?) {
   Card(
       modifier = Modifier.padding(16.dp).fillMaxWidth().aspectRatio(1.9f),
       shape = RoundedCornerShape(12.dp),

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/ImageCard.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/ImageCard.kt
@@ -1,5 +1,6 @@
 package com.monkeyteam.chimpagne.ui.components.eventview
 
+import android.net.Uri
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -13,12 +14,12 @@ import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.ui.components.ImageWithBlackFilterOverlay
 
 @Composable
-fun ImageCard(imageUrl: String) {
+fun ImageCard(imageUri: Uri?) {
   Card(
       modifier = Modifier.padding(16.dp).fillMaxWidth().aspectRatio(1.9f),
       shape = RoundedCornerShape(12.dp),
       colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
       elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)) {
-        ImageWithBlackFilterOverlay(imageUrl)
+        ImageWithBlackFilterOverlay(imageUri)
       }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/ImageCard.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/ImageCard.kt
@@ -1,5 +1,6 @@
 package com.monkeyteam.chimpagne.ui.components.eventview
 
+import android.util.Log
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -14,6 +15,7 @@ import com.monkeyteam.chimpagne.ui.components.ImageWithBlackFilterOverlay
 
 @Composable
 fun ImageCard(imageUri: String?) {
+  Log.d("AdvancedLogisticsPanel", "Event picture URI is: $imageUri")
   Card(
       modifier = Modifier.padding(16.dp).fillMaxWidth().aspectRatio(1.9f),
       shape = RoundedCornerShape(12.dp),

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/ImageCard.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/ImageCard.kt
@@ -1,6 +1,5 @@
 package com.monkeyteam.chimpagne.ui.components.eventview
 
-import android.util.Log
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -11,16 +10,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.monkeyteam.chimpagne.ui.components.ImageWithBlackFilterOverlay
+import com.monkeyteam.chimpagne.ui.components.ImageLoader
 
 @Composable
 fun ImageCard(imageUri: String?) {
-  Log.d("AdvancedLogisticsPanel", "Event picture URI is: $imageUri")
   Card(
       modifier = Modifier.padding(16.dp).fillMaxWidth().aspectRatio(1.9f),
       shape = RoundedCornerShape(12.dp),
       colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
       elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)) {
-        ImageWithBlackFilterOverlay(imageUri)
+        ImageLoader(imageUri)
       }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/OrganiserView.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/OrganiserView.kt
@@ -1,5 +1,6 @@
 package com.monkeyteam.chimpagne.ui.components.eventview
 
+import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.background
@@ -27,11 +28,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
@@ -50,7 +49,6 @@ fun OrganiserView(
 ) {
 
   val profilePictureUriState = remember { mutableStateOf<Uri?>(null) }
-  val clipboardManager = LocalClipboardManager.current
 
   LaunchedEffect(ownerId) {
     accountViewModel.fetchAccounts(listOf(ownerId))
@@ -97,12 +95,19 @@ fun OrganiserView(
                     .clip(RoundedCornerShape(12.dp))
                     .background(MaterialTheme.colorScheme.primaryContainer)
                     .clickable {
-                      val annotatedString = buildAnnotatedString {
-                        append(
-                            ContextCompat.getString(context, R.string.deep_link_url_event) +
-                                event.id)
-                      }
-                      clipboardManager.setText(annotatedString)
+                      val shareText =
+                          ContextCompat.getString(context, R.string.deep_link_url_event) + event.id
+                      val shareIntent =
+                          Intent().apply {
+                            // Intent is for sending data
+                            action = Intent.ACTION_SEND
+                            // Add the text to share to the intent
+                            putExtra(Intent.EXTRA_TEXT, shareText)
+                            // We are sharing plain text so this just sets the MIME type of the data
+                            type = "text/plain"
+                          }
+                      val chooserIntent = Intent.createChooser(shareIntent, null)
+                      context.startActivity(chooserIntent)
                     }
                     .padding(8.dp)) {
               Icon(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.icons.rounded.Layers
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -45,8 +44,6 @@ fun AdditionalFeaturesPanel(eventViewModel: EventViewModel) {
 
   var parkingText by remember { mutableStateOf(uiState.parkingSpaces.toString()) }
   var bedsText by remember { mutableStateOf(uiState.beds.toString()) }
-
-  LaunchedEffect(Unit) { eventViewModel.copyRealToTempImage() }
 
   val pickEventPicture =
       rememberLauncherForActivityResult(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
@@ -124,7 +124,7 @@ fun AdditionalFeaturesPanel(eventViewModel: EventViewModel) {
           ChimpagneButton(
               onClick = { pickEventPicture.launch(PickVisualMediaRequest()) },
               text = "Add Picture",
-              modifier = Modifier)
+              modifier = Modifier.testTag("EventPicture"))
         }
       }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
@@ -1,5 +1,10 @@
 package com.monkeyteam.chimpagne.ui.event
 
+import android.net.Uri
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -11,6 +16,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Bed
 import androidx.compose.material.icons.rounded.DirectionsCar
+import androidx.compose.material.icons.rounded.Image
 import androidx.compose.material.icons.rounded.Layers
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -26,23 +32,38 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.ui.components.ChimpagneButton
 import com.monkeyteam.chimpagne.ui.components.Legend
+import com.monkeyteam.chimpagne.ui.components.eventview.ImageCard
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 import kotlin.math.abs
 
 @Composable
-fun AdvancedLogisticsPanel(eventViewModel: EventViewModel) {
+fun AdditionalFeaturesPanel(eventViewModel: EventViewModel) {
   val uiState by eventViewModel.uiState.collectAsState()
 
   var parkingText by remember { mutableStateOf(uiState.parkingSpaces.toString()) }
   var bedsText by remember { mutableStateOf(uiState.beds.toString()) }
+
+  val pickEventPicture =
+      rememberLauncherForActivityResult(
+          contract = ActivityResultContracts.PickVisualMedia(),
+          onResult = { uri: Uri? ->
+            if (uri == null) {
+              Log.d("AdvancedLogisticsPanel", "Event picture URI is null")
+            } else {
+              eventViewModel.updateEventPicture(uri)
+            }
+          })
   Column(
       modifier = Modifier.padding(16.dp).fillMaxHeight(), verticalArrangement = Arrangement.Top) {
         Legend(
-            stringResource(id = R.string.event_creation_screen_logistics),
+            stringResource(id = R.string.event_creation_screen_additional_features),
             Icons.Rounded.Layers,
             "logistics_title")
         Spacer(modifier = Modifier.height(16.dp))
+
+        // Choosing number of parking spots
         Legend(
             stringResource(id = R.string.event_creation_screen_parking),
             Icons.Rounded.DirectionsCar,
@@ -61,6 +82,7 @@ fun AdvancedLogisticsPanel(eventViewModel: EventViewModel) {
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier.fillMaxWidth().testTag("n_parking"))
 
+        // Choosing number of beds
         Spacer(modifier = Modifier.height(16.dp))
         Legend(
             stringResource(id = R.string.event_creation_screen_beds),
@@ -79,5 +101,16 @@ fun AdvancedLogisticsPanel(eventViewModel: EventViewModel) {
             label = { Text(stringResource(id = R.string.event_creation_screen_number_beds)) },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier.fillMaxWidth().testTag("n_beds"))
+        // Event Image
+        Legend(
+            stringResource(id = R.string.event_picture_title),
+            Icons.Rounded.Image,
+            "event_picture_title")
+        ImageCard(uiState.imageUri)
+        Spacer(modifier = Modifier.height(16.dp))
+        ChimpagneButton(
+            onClick = { pickEventPicture.launch(PickVisualMediaRequest()) },
+            text = "Add Picture",
+            modifier = Modifier)
       }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.rounded.Layers
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -45,6 +46,8 @@ fun AdditionalFeaturesPanel(eventViewModel: EventViewModel) {
   var parkingText by remember { mutableStateOf(uiState.parkingSpaces.toString()) }
   var bedsText by remember { mutableStateOf(uiState.beds.toString()) }
 
+  LaunchedEffect(Unit) { eventViewModel.copyRealToTempImage() }
+
   val pickEventPicture =
       rememberLauncherForActivityResult(
           contract = ActivityResultContracts.PickVisualMedia(),
@@ -52,7 +55,7 @@ fun AdditionalFeaturesPanel(eventViewModel: EventViewModel) {
             if (uri == null) {
               Log.d("AdvancedLogisticsPanel", "Event picture URI is null")
             } else {
-              eventViewModel.updateTempEventPicture(uri)
+              eventViewModel.updateTempEventPicture(uri.toString())
             }
           })
   Column(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
@@ -52,7 +52,7 @@ fun AdditionalFeaturesPanel(eventViewModel: EventViewModel) {
             if (uri == null) {
               Log.d("AdvancedLogisticsPanel", "Event picture URI is null")
             } else {
-              eventViewModel.updateEventPicture(uri)
+              eventViewModel.updateTempEventPicture(uri)
             }
           })
   Column(
@@ -106,7 +106,7 @@ fun AdditionalFeaturesPanel(eventViewModel: EventViewModel) {
             stringResource(id = R.string.event_picture_title),
             Icons.Rounded.Image,
             "event_picture_title")
-        ImageCard(uiState.imageUri)
+        ImageCard(uiState.tempImageUri)
         Spacer(modifier = Modifier.height(16.dp))
         ChimpagneButton(
             onClick = { pickEventPicture.launch(PickVisualMediaRequest()) },

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/AdditionalFeaturesPanel.kt
@@ -6,12 +6,12 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Bed
@@ -55,62 +55,76 @@ fun AdditionalFeaturesPanel(eventViewModel: EventViewModel) {
               eventViewModel.updateTempEventPicture(uri.toString())
             }
           })
-  Column(
+
+  LazyColumn(
       modifier = Modifier.padding(16.dp).fillMaxHeight(), verticalArrangement = Arrangement.Top) {
-        Legend(
-            stringResource(id = R.string.event_creation_screen_additional_features),
-            Icons.Rounded.Layers,
-            "logistics_title")
-        Spacer(modifier = Modifier.height(16.dp))
+        item {
+          Legend(
+              stringResource(id = R.string.event_creation_screen_additional_features),
+              Icons.Rounded.Layers,
+              "logistics_title")
+          Spacer(modifier = Modifier.height(16.dp))
+        }
 
-        // Choosing number of parking spots
-        Legend(
-            stringResource(id = R.string.event_creation_screen_parking),
-            Icons.Rounded.DirectionsCar,
-            "parking_title")
-        OutlinedTextField(
-            value = parkingText,
-            onValueChange = {
-              parkingText = it
-              try {
-                eventViewModel.updateParkingSpaces(abs(parkingText.toInt()))
-              } catch (_: Exception) {
-                eventViewModel.updateParkingSpaces(0)
-              }
-            },
-            label = { Text(stringResource(id = R.string.event_creation_screen_number_parking)) },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth().testTag("n_parking"))
+        item {
+          // Choosing number of parking spots
+          Legend(
+              stringResource(id = R.string.event_creation_screen_parking),
+              Icons.Rounded.DirectionsCar,
+              "parking_title")
+          OutlinedTextField(
+              value = parkingText,
+              onValueChange = {
+                parkingText = it
+                try {
+                  eventViewModel.updateParkingSpaces(abs(parkingText.toInt()))
+                } catch (_: Exception) {
+                  eventViewModel.updateParkingSpaces(0)
+                }
+              },
+              label = { Text(stringResource(id = R.string.event_creation_screen_number_parking)) },
+              keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+              modifier = Modifier.fillMaxWidth().testTag("n_parking"))
+          Spacer(modifier = Modifier.height(16.dp))
+        }
 
-        // Choosing number of beds
-        Spacer(modifier = Modifier.height(16.dp))
-        Legend(
-            stringResource(id = R.string.event_creation_screen_beds),
-            Icons.Rounded.Bed,
-            "beds_title")
-        OutlinedTextField(
-            value = bedsText,
-            onValueChange = {
-              bedsText = it
-              try {
-                eventViewModel.updateBeds(abs(bedsText.toInt()))
-              } catch (_: Exception) {
-                eventViewModel.updateBeds(0)
-              }
-            },
-            label = { Text(stringResource(id = R.string.event_creation_screen_number_beds)) },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth().testTag("n_beds"))
-        // Event Image
-        Legend(
-            stringResource(id = R.string.event_picture_title),
-            Icons.Rounded.Image,
-            "event_picture_title")
-        ImageCard(uiState.tempImageUri)
-        Spacer(modifier = Modifier.height(16.dp))
-        ChimpagneButton(
-            onClick = { pickEventPicture.launch(PickVisualMediaRequest()) },
-            text = "Add Picture",
-            modifier = Modifier)
+        item {
+          // Choosing number of beds
+          Legend(
+              stringResource(id = R.string.event_creation_screen_beds),
+              Icons.Rounded.Bed,
+              "beds_title")
+          OutlinedTextField(
+              value = bedsText,
+              onValueChange = {
+                bedsText = it
+                try {
+                  eventViewModel.updateBeds(abs(bedsText.toInt()))
+                } catch (_: Exception) {
+                  eventViewModel.updateBeds(0)
+                }
+              },
+              label = { Text(stringResource(id = R.string.event_creation_screen_number_beds)) },
+              keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+              modifier = Modifier.fillMaxWidth().testTag("n_beds"))
+          Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        item {
+          // Event Image
+          Legend(
+              stringResource(id = R.string.event_picture_title),
+              Icons.Rounded.Image,
+              "event_picture_title")
+          ImageCard(uiState.tempImageUri)
+          Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        item {
+          ChimpagneButton(
+              onClick = { pickEventPicture.launch(PickVisualMediaRequest()) },
+              text = "Add Picture",
+              modifier = Modifier)
+        }
       }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -39,10 +38,6 @@ fun EditEventScreen(
   fun showToast(message: String) {
     Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
   }
-
-  LaunchedEffect(Unit) {
-    eventViewModel.fetchEvent({ eventViewModel.copyRealToTempImage() }, {})
-  } // Doesn't work yet
 
   Scaffold(
       topBar = {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -38,6 +39,8 @@ fun EditEventScreen(
   fun showToast(message: String) {
     Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
   }
+
+  LaunchedEffect(Unit) { eventViewModel.copyRealToTempImage() }
   Scaffold(
       topBar = {
         TopBar(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
@@ -40,7 +40,10 @@ fun EditEventScreen(
     Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
   }
 
-  LaunchedEffect(Unit) { eventViewModel.copyRealToTempImage() }
+  LaunchedEffect(Unit) {
+    eventViewModel.fetchEvent({ eventViewModel.copyRealToTempImage() }, {})
+  } // Doesn't work yet
+
   Scaffold(
       topBar = {
         TopBar(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
@@ -82,7 +82,7 @@ fun EditEventScreen(
           when (page) {
             0 -> FirstPanel(eventViewModel)
             1 -> TagsAndPubPanel(eventViewModel)
-            2 -> AdvancedLogisticsPanel(eventViewModel)
+            2 -> AdditionalFeaturesPanel(eventViewModel)
             3 -> ChooseSocialsPanel(eventViewModel)
           }
         }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -42,6 +43,8 @@ fun EventCreationScreen(
   fun showToast(message: String) {
     Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
   }
+
+  LaunchedEffect(Unit) { eventViewModel.copyRealToTempImage() }
 
   BackHandler {
     if (pagerState.currentPage > 0) {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -43,8 +42,6 @@ fun EventCreationScreen(
   fun showToast(message: String) {
     Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
   }
-
-  LaunchedEffect(Unit) { eventViewModel.copyRealToTempImage() }
 
   BackHandler {
     if (pagerState.currentPage > 0) {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -86,7 +86,7 @@ fun EventCreationScreen(
                 0 -> FirstPanel(eventViewModel)
                 1 -> TagsAndPubPanel(eventViewModel)
                 2 -> SuppliesPanel(eventViewModel)
-                3 -> AdvancedLogisticsPanel(eventViewModel)
+                3 -> AdditionalFeaturesPanel(eventViewModel)
                 4 -> ChooseSocialsPanel(eventViewModel)
               }
             }

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -1,6 +1,7 @@
 package com.monkeyteam.chimpagne.viewmodels
 
 import android.content.Context
+import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -97,7 +98,7 @@ class EventViewModel(
                         parkingSpaces = it.parkingSpaces,
                         beds = it.beds,
                         ownerId = it.ownerId,
-                        imageUrl = it.imageUrl,
+                        imageUri = it.imageUri,
                         socialMediaLinks = convertSMLinksToSM(it.socialMediaLinks),
                         polls = it.polls)
                 _uiState.value =
@@ -141,7 +142,7 @@ class EventViewModel(
         supplies = _uiState.value.supplies,
         parkingSpaces = _uiState.value.parkingSpaces,
         beds = _uiState.value.beds,
-        imageUrl = "",
+        imageUri = _uiState.value.imageUri,
         socialMediaLinks = convertSMToSMLinks(_uiState.value.socialMediaLinks),
         polls = _uiState.value.polls)
   }
@@ -358,6 +359,10 @@ class EventViewModel(
                     (updatedSocialMedia.platformName to updatedSocialMedia))
   }
 
+  fun updateEventPicture(uri: Uri) {
+    _uiState.value = _uiState.value.copy(imageUri = uri)
+  }
+
   fun getCurrentUserRole(): ChimpagneRole {
     return getRole(accountManager.currentUserAccount?.firebaseAuthUID ?: "")
   }
@@ -565,7 +570,7 @@ class EventViewModel(
             parkingSpaces = event.parkingSpaces,
             beds = event.beds,
             ownerId = event.ownerId,
-            imageUrl = event.imageUrl,
+            imageUri = event.imageUri,
             socialMediaLinks = convertSMLinksToSM(event.socialMediaLinks),
             polls = event.polls,
             currentUserRole = getRole(accountManager.currentUserAccount?.firebaseAuthUID ?: ""))
@@ -587,7 +592,7 @@ class EventViewModel(
       val supplies: Map<ChimpagneSupplyId, ChimpagneSupply> = mapOf(),
       val parkingSpaces: Int = 0,
       val beds: Int = 0,
-      val imageUrl: String = "",
+      val imageUri: Uri? = null,
       val polls: Map<ChimpagnePollId, ChimpagnePoll> = emptyMap(),
 
       // unmodifiable by the UI

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -576,6 +576,7 @@ class EventViewModel(
             beds = event.beds,
             ownerId = event.ownerId,
             socialMediaLinks = convertSMLinksToSM(event.socialMediaLinks),
+            imageUri = event.imageUri,
             polls = event.polls,
             currentUserRole = getRole(accountManager.currentUserAccount?.firebaseAuthUID ?: ""))
   }

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -359,8 +359,12 @@ class EventViewModel(
                     (updatedSocialMedia.platformName to updatedSocialMedia))
   }
 
-  fun updateEventPicture(uri: Uri) {
-    _uiState.value = _uiState.value.copy(imageUri = uri)
+  fun updateTempEventPicture(uri: Uri) {
+    _uiState.value = _uiState.value.copy(tempImageUri = uri)
+  }
+
+  fun copyRealToTempImage() {
+    _uiState.value = _uiState.value.copy(tempImageUri = _uiState.value.imageUri)
   }
 
   fun getCurrentUserRole(): ChimpagneRole {
@@ -592,13 +596,14 @@ class EventViewModel(
       val supplies: Map<ChimpagneSupplyId, ChimpagneSupply> = mapOf(),
       val parkingSpaces: Int = 0,
       val beds: Int = 0,
+      val tempImageUri: Uri? = null,
       val imageUri: Uri? = null,
       val polls: Map<ChimpagnePollId, ChimpagnePoll> = emptyMap(),
 
       // unmodifiable by the UI
       val ownerId: ChimpagneAccountUID = "",
       val currentUserRole: ChimpagneRole = ChimpagneRole.NOT_IN_EVENT,
-      val loading: Boolean = true,
+      val loading: Boolean = false,
       val socialMediaLinks: Map<String, SocialMedia> =
           SupportedSocialMedia.associateBy { it.platformName }
   )

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -202,8 +202,8 @@ class EventViewModel(
         eventManager.updateEvent(
             buildChimpagneEvent(),
             {
-              _uiState.value =
-                  _uiState.value.copy(loading = false, imageUri = newEventPicture.toString())
+              _uiState.value = _uiState.value.copy(imageUri = newEventPicture.toString())
+              _uiState.value = _uiState.value.copy(loading = false)
               onSuccess()
             },
             {
@@ -366,12 +366,6 @@ class EventViewModel(
 
   fun updateTempEventPicture(uri: String) {
     _uiState.value = _uiState.value.copy(tempImageUri = uri)
-  }
-
-  fun copyRealToTempImage() {
-    Log.d("EventViewModelTR", "Old image URI: ${_uiState.value.tempImageUri}")
-    Log.d("EventViewModelTR", "New image URI: ${_uiState.value.imageUri}")
-    _uiState.value = _uiState.value.copy(tempImageUri = _uiState.value.imageUri)
   }
 
   fun getCurrentUserRole(): ChimpagneRole {

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -104,6 +104,7 @@ class EventViewModel(
                     _uiState.value.copy(
                         currentUserRole =
                             getRole(accountManager.currentUserAccount?.firebaseAuthUID ?: ""))
+                _uiState.value = _uiState.value.copy(tempImageUri = _uiState.value.imageUri)
                 onSuccess()
                 _uiState.value = _uiState.value.copy(loading = false)
               } else {

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -559,6 +559,7 @@ class EventViewModel(
   }
 
   fun updateUIStateWithEvent(event: ChimpagneEvent) {
+    eventID = event.id
     _uiState.value =
         EventUIState(
             id = event.id,

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -79,8 +79,7 @@ class EventViewModel(
       viewModelScope.launch {
         eventManager.getEventById(
             eventID!!,
-            { event, uri ->
-              Log.d("EventViewModel", "Fetched event: $event with URI: $uri")
+            { event ->
               if (event != null) {
                 _uiState.value =
                     EventUIState(
@@ -97,7 +96,7 @@ class EventViewModel(
                         supplies = event.supplies,
                         parkingSpaces = event.parkingSpaces,
                         beds = event.beds,
-                        imageUri = uri,
+                        imageUri = event.imageUri,
                         ownerId = event.ownerId,
                         socialMediaLinks = convertSMLinksToSM(event.socialMediaLinks),
                         polls = event.polls)
@@ -369,6 +368,8 @@ class EventViewModel(
   }
 
   fun copyRealToTempImage() {
+    Log.d("EventViewModelTR", "Old image URI: ${_uiState.value.tempImageUri}")
+    Log.d("EventViewModelTR", "New image URI: ${_uiState.value.imageUri}")
     _uiState.value = _uiState.value.copy(tempImageUri = _uiState.value.imageUri)
   }
 

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -197,17 +197,20 @@ class EventViewModel(
     } else {
       _uiState.value = _uiState.value.copy(loading = true)
       viewModelScope.launch {
+        val newEventPicture = _uiState.value.tempImageUri
         eventManager.updateEvent(
             buildChimpagneEvent(),
             {
-              _uiState.value = _uiState.value.copy(loading = false)
+              _uiState.value =
+                  _uiState.value.copy(loading = false, imageUri = newEventPicture.toString())
               onSuccess()
             },
             {
               Log.d("UPDATE AN EVENT", "Error : ", it)
               _uiState.value = _uiState.value.copy(loading = false)
               onFailure(it)
-            })
+            },
+            newEventPicture)
       }
     }
   }

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -80,6 +80,7 @@ class EventViewModel(
         eventManager.getEventById(
             eventID!!,
             { event, uri ->
+              Log.d("EventViewModel", "Fetched event: $event with URI: $uri")
               if (event != null) {
                 _uiState.value =
                     EventUIState(

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/FindEventsViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/FindEventsViewModel.kt
@@ -131,9 +131,12 @@ class FindEventsViewModel(database: Database) : ViewModel() {
       try {
         eventManager.getEventById(
             id,
-            {
-              if (it != null) {
-                _uiState.value = _uiState.value.copy(events = mapOf(it.id to it), loading = false)
+            { event, pictureUri ->
+              if (event != null) {
+                val eventWithPicture = event.copy(imageUri = pictureUri)
+                _uiState.value =
+                    _uiState.value.copy(
+                        events = mapOf(eventWithPicture.id to eventWithPicture), loading = false)
                 onSuccess()
               } else {
                 Log.d("FETCHING AN EVENT WITH ID", "Error : no such event exists")

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/FindEventsViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/FindEventsViewModel.kt
@@ -131,12 +131,10 @@ class FindEventsViewModel(database: Database) : ViewModel() {
       try {
         eventManager.getEventById(
             id,
-            { event, pictureUri ->
+            { event ->
               if (event != null) {
-                val eventWithPicture = event.copy(imageUri = pictureUri)
                 _uiState.value =
-                    _uiState.value.copy(
-                        events = mapOf(eventWithPicture.id to eventWithPicture), loading = false)
+                    _uiState.value.copy(events = mapOf(event.id to event), loading = false)
                 onSuccess()
               } else {
                 Log.d("FETCHING AN EVENT WITH ID", "Error : no such event exists")

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -27,7 +27,8 @@
     <string name="event_creation_screen_event_made_public">Cet événement a été rendu publique !</string>
     <string name="event_creation_screen_make_event_public">Rendre cet événement publique</string>
     <string name="event_creation_screen_public_legend">Visibilité De l\'événement</string>
-    <string name="event_creation_screen_logistics">Aménagements</string>
+    <string name="event_creation_screen_additional_features">Fonctionnalités supplémentaires</string>
+    <string name="event_picture_title">Image de l\'événement</string>
     <string name="event_creation_screen_parking">Parking</string>
     <string name="event_creation_screen_number_parking">Nombre de places de parque</string>
     <string name="event_creation_screen_number_beds">Nombre de lits</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,8 @@
     <string name="event_creation_screen_event_made_public">This event has been made public !</string>
     <string name="event_creation_screen_make_event_public">Make this event public</string>
     <string name="event_creation_screen_public_legend">Event Publicity</string>
-    <string name="event_creation_screen_logistics">Accommodations</string>
+    <string name="event_creation_screen_additional_features">Additional Features</string>
+    <string name="event_picture_title">Event Picture</string>
     <string name="event_creation_screen_parking">Parking</string>
     <string name="event_creation_screen_number_parking">Number of parking places</string>
     <string name="event_creation_screen_number_beds">Number of beds</string>


### PR DESCRIPTION
This PR aims to integrate Android's Share Sheet in the EventScreen.kt file (see: https://developer.android.com/training/sharing/send) for easier sharing of events. 

We had mentioned in our discussions that we wanted it to be clear that the event link is copied to the clipboard (adding a Chimpagne Toast), however,  I believe a toast is not necessary anymore because with the Android Share Sheet there is a by default toast now. Note that this does not show on the emulator for clipboard accessibility issues (see the video below to see how it works on an android phone)

I realize now that I may have created a new branch for this PR from @Kuriv2001 's branch for the event pictures that I was locally testing to review... So my code has 100% of line coverage but I needed to add a test for the existence of the event picture in order to have my CI passing. 


https://github.com/Chimpagne/ChimpagneApp/assets/60262512/fa8b7498-795f-47f6-a95d-89805d5fd756

