### PR TITLE
Android Share Sheet

### DIFF
--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/OrganiserView.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/eventview/OrganiserView.kt
@@ -1,5 +1,6 @@
 package com.monkeyteam.chimpagne.ui.components.eventview
 
+import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.background
@@ -27,11 +28,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
@@ -50,7 +49,6 @@ fun OrganiserView(
 ) {
 
   val profilePictureUriState = remember { mutableStateOf<Uri?>(null) }
-  val clipboardManager = LocalClipboardManager.current
 
   LaunchedEffect(ownerId) {
     accountViewModel.fetchAccounts(listOf(ownerId))
@@ -97,12 +95,19 @@ fun OrganiserView(
                     .clip(RoundedCornerShape(12.dp))
                     .background(MaterialTheme.colorScheme.primaryContainer)
                     .clickable {
-                      val annotatedString = buildAnnotatedString {
-                        append(
-                            ContextCompat.getString(context, R.string.deep_link_url_event) +
-                                event.id)
-                      }
-                      clipboardManager.setText(annotatedString)
+                      val shareText =
+                          ContextCompat.getString(context, R.string.deep_link_url_event) + event.id
+                      val shareIntent =
+                          Intent().apply {
+                            // Intent is for sending data
+                            action = Intent.ACTION_SEND
+                            // Add the text to share to the intent
+                            putExtra(Intent.EXTRA_TEXT, shareText)
+                            // We are sharing plain text so this just sets the MIME type of the data
+                            type = "text/plain"
+                          }
+                      val chooserIntent = Intent.createChooser(shareIntent, null)
+                      context.startActivity(chooserIntent)
                     }
                     .padding(8.dp)) {
               Icon(


### PR DESCRIPTION
This PR aims to integrate Android's Share Sheet in the EventScreen.kt file (see: https://developer.android.com/training/sharing/send) for easier sharing of events.) This resolves Issue #205 

We had mentioned in our discussions that we wanted it to be clear that the event link is copied to the clipboard (adding a Chimpagne Toast), however, I believe a toast is not necessary anymore because with the Android Share Sheet there is a by default toast now. Note that this does not show on the emulator for clipboard accessibility issues (see the video below to see how it works on an android phone)


https://github.com/Chimpagne/ChimpagneApp/assets/60262512/b2114197-5ef0-49e9-b112-b85758e0ce99

