### PR TITLE
Consistent use of the TopBar and GoBackButton components

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/FindEventScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/FindEventScreenTest.kt
@@ -19,7 +19,6 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
-import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
 import com.monkeyteam.chimpagne.ui.EventScreen
 import com.monkeyteam.chimpagne.ui.FindEventFormScreen
 import com.monkeyteam.chimpagne.ui.FindEventMapScreen
@@ -62,7 +61,7 @@ class FindEventScreenTest {
 
   @Before
   fun init() {
-    initializeTestDatabase()
+    //    initializeTestDatabase()
   }
 
   @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/FindEventScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/FindEventScreenTest.kt
@@ -62,7 +62,7 @@ class FindEventScreenTest {
 
   @Before
   fun init() {
-        initializeTestDatabase()
+    initializeTestDatabase()
   }
 
   @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/FindEventScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/FindEventScreenTest.kt
@@ -19,6 +19,7 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.Database
 import com.monkeyteam.chimpagne.newtests.TEST_ACCOUNTS
+import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
 import com.monkeyteam.chimpagne.ui.EventScreen
 import com.monkeyteam.chimpagne.ui.FindEventFormScreen
 import com.monkeyteam.chimpagne.ui.FindEventMapScreen
@@ -61,7 +62,7 @@ class FindEventScreenTest {
 
   @Before
   fun init() {
-    //    initializeTestDatabase()
+        initializeTestDatabase()
   }
 
   @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/FindEventScreenTest.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/FindEventScreenTest.kt
@@ -3,8 +3,10 @@ package com.monkeyteam.chimpagne
 import android.location.LocationManager
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -219,7 +221,7 @@ class FindEventScreenTest {
     assertTrue(eventViewModel.getRole(myAccount.firebaseAuthUID) == ChimpagneRole.OWNER)
   }
 
-  @OptIn(ExperimentalMaterial3Api::class)
+  @OptIn(ExperimentalMaterial3Api::class, ExperimentalTestApi::class)
   @Test
   fun displayTitle() {
     composeTestRule.setContent {
@@ -233,7 +235,7 @@ class FindEventScreenTest {
           accountViewModel)
     }
 
-    composeTestRule.onNodeWithTag("screen title").assertIsDisplayed()
+    composeTestRule.waitUntilAtLeastOneExists(hasTestTag("screen title"), 10)
   }
 
   @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ManageStaffScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ManageStaffScreenTests.kt
@@ -73,8 +73,7 @@ class ManageStaffScreenTests {
       ManageStaffScreen(navActions, eventVM, accountVM)
     }
 
-    composeTestRule.onNodeWithTag("go_back_button").assertHasClickAction()
-    composeTestRule.onNodeWithContentDescription("back").performClick()
+    composeTestRule.onNodeWithTag("go_back_button").performClick()
   }
 
   @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ManageStaffScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ManageStaffScreenTests.kt
@@ -73,7 +73,7 @@ class ManageStaffScreenTests {
       ManageStaffScreen(navActions, eventVM, accountVM)
     }
 
-    composeTestRule.onNodeWithContentDescription("back").assertHasClickAction()
+    composeTestRule.onNodeWithTag("go_back_button").assertHasClickAction()
     composeTestRule.onNodeWithContentDescription("back").performClick()
   }
 

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/MyEventsScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/MyEventsScreenTests.kt
@@ -69,7 +69,7 @@ class MyEventsScreenTests {
       MyEventsScreen(navActions, myEventVM)
     }
 
-    composeTestRule.onNodeWithContentDescription("back").assertHasClickAction()
+    composeTestRule.onNodeWithTag("go_back_button").assertHasClickAction()
     composeTestRule.onNodeWithContentDescription("back").performClick()
   }
 

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/MyEventsScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/MyEventsScreenTests.kt
@@ -2,7 +2,6 @@ package com.monkeyteam.chimpagne.newtests.ui
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.test.*
-import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -69,8 +68,7 @@ class MyEventsScreenTests {
       MyEventsScreen(navActions, myEventVM)
     }
 
-    composeTestRule.onNodeWithTag("go_back_button").assertHasClickAction()
-    composeTestRule.onNodeWithContentDescription("back").performClick()
+    composeTestRule.onNodeWithTag("go_back_button").performClick()
   }
 
   @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/PollsAndVotingScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/PollsAndVotingScreenTests.kt
@@ -46,7 +46,7 @@ class PollsAndVotingScreenTests {
 
     composeTestRule.onNodeWithTag("screen title").assertIsDisplayed()
     composeTestRule.onNodeWithContentDescription("create poll button").assertIsDisplayed()
-    composeTestRule.onNodeWithContentDescription("back").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("go_back_button").assertIsDisplayed()
     composeTestRule.onNodeWithContentDescription("poll legend text").assertIsDisplayed()
     composeTestRule.onNodeWithTag("empty poll list").assertIsDisplayed()
   }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ViewDetailEventScreenTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/ui/ViewDetailEventScreenTests.kt
@@ -113,7 +113,7 @@ class ViewDetailEventScreenTests {
       EventScreen(navActions, eventVM, accountViewModel)
     }
 
-    composeTestRule.onNodeWithTag("event title").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("screen title").assertIsDisplayed()
   }
 
   @OptIn(ExperimentalFoundationApi::class)
@@ -276,8 +276,7 @@ class ViewDetailEventScreenTests {
       EventScreen(navActions, eventVM, accountViewModel)
     }
 
-    composeTestRule.onNodeWithTag("go_back").assertHasClickAction()
-    composeTestRule.onNodeWithTag("go_back").performClick()
+    composeTestRule.onNodeWithTag("go_back_button").performClick()
   }
 
   @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/EventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/EventScreen.kt
@@ -23,17 +23,14 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.Login
 import androidx.compose.material.icons.rounded.QrCodeScanner
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -51,7 +48,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.monkeyteam.chimpagne.R
@@ -59,6 +55,8 @@ import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.utils.createCalendarIntent
 import com.monkeyteam.chimpagne.ui.components.EventTagChip
+import com.monkeyteam.chimpagne.ui.components.GoBackButton
+import com.monkeyteam.chimpagne.ui.components.TopBar
 import com.monkeyteam.chimpagne.ui.components.eventview.ChimpagneDivider
 import com.monkeyteam.chimpagne.ui.components.eventview.EventActions
 import com.monkeyteam.chimpagne.ui.components.eventview.EventDescription
@@ -144,22 +142,9 @@ fun EventScreen(
 
   Scaffold(
       topBar = {
-        TopAppBar(
-            title = {
-              Text(
-                  text = uiState.title,
-                  style = ChimpagneTypography.titleLarge,
-                  textAlign = TextAlign.Center,
-                  maxLines = 2,
-                  overflow = TextOverflow.Ellipsis,
-                  modifier = Modifier.fillMaxWidth().testTag("event title"))
-            },
-            modifier = Modifier.shadow(4.dp),
-            navigationIcon = {
-              IconButton(onClick = { goBack() }, modifier = Modifier.testTag("go_back")) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-              }
-            },
+        TopBar(
+            text = uiState.title,
+            navigationIcon = { GoBackButton(goBack) },
             actions = {
               Box(
                   modifier =

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/ManageStaffScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/ManageStaffScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.rounded.CheckBox
 import androidx.compose.material.icons.rounded.CheckBoxOutlineBlank
 import androidx.compose.material.icons.rounded.Edit
@@ -28,11 +27,9 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -41,7 +38,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -49,7 +45,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.ui.components.GoBackButton
 import com.monkeyteam.chimpagne.ui.components.Legend
+import com.monkeyteam.chimpagne.ui.components.TopBar
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.ui.theme.ChimpagneFontFamily
 import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
@@ -68,24 +66,17 @@ fun ManageStaffScreen(
 
   Scaffold(
       topBar = {
-        TopAppBar(
-            title = {
-              Text(
-                  stringResource(id = R.string.manage_staff_screen_title),
-                  Modifier.testTag("screen title"))
-            },
-            modifier = Modifier.shadow(4.dp),
+        TopBar(
+            text = stringResource(id = R.string.manage_staff_screen_title),
             navigationIcon = {
-              IconButton(
+              GoBackButton(
                   onClick = {
                     if (isOnEdit) {
                       eventViewModel.fetchEvent({ isOnEdit = false })
                     } else {
                       navObject.goBack()
                     }
-                  }) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-                  }
+                  })
             })
       },
       floatingActionButton = {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
@@ -9,13 +9,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.rounded.Create
 import androidx.compose.material.icons.rounded.HourglassBottom
 import androidx.compose.material.icons.rounded.Public
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -29,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.ui.components.EventCard
+import com.monkeyteam.chimpagne.ui.components.GoBackButton
 import com.monkeyteam.chimpagne.ui.components.Legend
 import com.monkeyteam.chimpagne.ui.components.TopBar
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
@@ -43,11 +41,7 @@ fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsView
       topBar = {
         TopBar(
             text = stringResource(id = R.string.my_events_screen_name),
-            navigationIcon = {
-              IconButton(onClick = { navObject.goBack() }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-              }
-            })
+            navigationIcon = { GoBackButton { navObject.goBack() } })
       }) { innerPadding ->
         Column(
             modifier =

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/Button.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/Button.kt
@@ -53,7 +53,6 @@ import androidx.core.content.ContextCompat.startActivity
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.database.ChimpagneEvent
 import com.monkeyteam.chimpagne.model.utils.createCalendarIntent
-import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.ui.theme.ChimpagneFontFamily
 import com.monkeyteam.chimpagne.ui.theme.ChimpagneTypography
 import java.util.Locale
@@ -115,19 +114,19 @@ fun IconTextButton(
         Text(text.uppercase(Locale.ROOT), style = textStyle)
       }
 }
-
-@Deprecated(
-    "Use GoBackButton(onClick: () -> Unit) instead",
-    replaceWith = ReplaceWith("GoBackButton(onClick = onGoBack)"))
-@Composable
-fun GoBackButton(navigationActions: NavigationActions) {
-  IconButton(onClick = { navigationActions.goBack() }) {
-    Icon(
-        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-        contentDescription = "Go Back",
-        tint = MaterialTheme.colorScheme.onSurface)
-  }
-}
+//
+// @Deprecated(
+//    "Use GoBackButton(onClick: () -> Unit) instead",
+//    replaceWith = ReplaceWith("GoBackButton(onClick = onGoBack)"))
+// @Composable
+// fun GoBackButton(navigationActions: NavigationActions) {
+//  IconButton(onClick = { navigationActions.goBack() }) {
+//    Icon(
+//        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+//        contentDescription = "Go Back",
+//        tint = MaterialTheme.colorScheme.onSurface)
+//  }
+// }
 
 @Composable
 fun GoBackButton(onClick: () -> Unit) {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/Button.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/Button.kt
@@ -114,19 +114,6 @@ fun IconTextButton(
         Text(text.uppercase(Locale.ROOT), style = textStyle)
       }
 }
-//
-// @Deprecated(
-//    "Use GoBackButton(onClick: () -> Unit) instead",
-//    replaceWith = ReplaceWith("GoBackButton(onClick = onGoBack)"))
-// @Composable
-// fun GoBackButton(navigationActions: NavigationActions) {
-//  IconButton(onClick = { navigationActions.goBack() }) {
-//    Icon(
-//        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-//        contentDescription = "Go Back",
-//        tint = MaterialTheme.colorScheme.onSurface)
-//  }
-// }
 
 @Composable
 fun GoBackButton(onClick: () -> Unit) {

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/TopBar.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/TopBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.ui.theme.ChimpagneFontFamily
 
@@ -26,6 +27,7 @@ fun TopBar(
             text = text,
             style = MaterialTheme.typography.headlineMedium,
             fontFamily = ChimpagneFontFamily,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.padding(16.dp))
       },
       actions = actions,

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EditEventScreen.kt
@@ -5,10 +5,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -17,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.ui.components.GoBackButton
 import com.monkeyteam.chimpagne.ui.components.TopBar
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
@@ -43,11 +40,7 @@ fun EditEventScreen(
       topBar = {
         TopBar(
             text = stringResource(id = R.string.edit_event),
-            navigationIcon = {
-              IconButton(onClick = { navObject.goBack() }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-              }
-            })
+            navigationIcon = { GoBackButton { navObject.goBack() } })
       },
       bottomBar = {
         PanelBottomBar(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/EventCreationScreen.kt
@@ -6,10 +6,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -19,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.monkeyteam.chimpagne.R
+import com.monkeyteam.chimpagne.ui.components.GoBackButton
 import com.monkeyteam.chimpagne.ui.components.TopBar
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
@@ -55,11 +52,7 @@ fun EventCreationScreen(
       topBar = {
         TopBar(
             text = stringResource(id = R.string.event_creation_screen_title),
-            navigationIcon = {
-              IconButton(onClick = { navObject.goBack() }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-              }
-            })
+            navigationIcon = { GoBackButton { navObject.goBack() } })
       },
       bottomBar = {
         PanelBottomBar(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -22,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -31,6 +29,7 @@ import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.model.database.ChimpagneSupply
 import com.monkeyteam.chimpagne.ui.components.GoBackButton
+import com.monkeyteam.chimpagne.ui.components.TopBar
 import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
@@ -133,10 +132,9 @@ fun SuppliesScreen(
         }
       },
       topBar = {
-        TopAppBar(
-            title = { Text(stringResource(id = R.string.supplies_screen_title)) },
-            modifier = Modifier.shadow(4.dp),
-            navigationIcon = { GoBackButton(navObject) })
+        TopBar(
+            text = stringResource(id = R.string.supplies_screen_title),
+            navigationIcon = { GoBackButton { navObject.goBack() } })
       }) { innerPadding ->
         if (eventUiState.supplies.isEmpty()) {
           Text(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/polls/PollAndVotingScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/polls/PollAndVotingScreen.kt
@@ -11,17 +11,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Poll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -30,14 +27,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.monkeyteam.chimpagne.R
 import com.monkeyteam.chimpagne.model.database.ChimpagneRole
 import com.monkeyteam.chimpagne.ui.components.ChimpagneButton
+import com.monkeyteam.chimpagne.ui.components.GoBackButton
 import com.monkeyteam.chimpagne.ui.components.Legend
+import com.monkeyteam.chimpagne.ui.components.TopBar
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -57,18 +55,9 @@ fun PollsAndVotingScreen(eventViewModel: EventViewModel, onGoBack: () -> Unit) {
   }
   Scaffold(
       topBar = {
-        TopAppBar(
-            title = {
-              Text(
-                  stringResource(id = R.string.polls_topbar_title),
-                  Modifier.testTag("screen title"))
-            },
-            modifier = Modifier.shadow(4.dp),
-            navigationIcon = {
-              IconButton(onClick = { onGoBack() }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "back")
-              }
-            })
+        TopBar(
+            text = stringResource(id = R.string.polls_topbar_title),
+            navigationIcon = { GoBackButton(onGoBack) })
       },
       floatingActionButton = {
         if (listOf(ChimpagneRole.OWNER, ChimpagneRole.STAFF)


### PR DESCRIPTION
This PR aims to bring more consistency within the app: 
- the usage of TopAppBar has been replaced by our custom TopBar in all the app
- screens not yet using our GoBackButton have been updated
- the deprecated version of GoBackButton has been removed
- tests have been updated accordingly