### PR TITLE
fixed ordering issues

### DIFF
--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneEventManager.kt
@@ -68,7 +68,7 @@ class ChimpagneEventManager(
           }
 
           // matchingEvents contains the results
-          onSuccess(matchingEvents)
+          onSuccess(matchingEvents.sortedBy { it.startsAtTimestamp })
         }
         .addOnFailureListener { onFailure(it) }
   }
@@ -218,7 +218,7 @@ class ChimpagneEventManager(
               events.add(event)
             }
           }
-          onSuccess(events)
+          onSuccess(events.sortedBy { it.startsAtTimestamp })
         }
         .addOnFailureListener { onFailure(it) }
   }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/DetailScreenSheet.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/DetailScreenSheet.kt
@@ -57,7 +57,7 @@ fun DetailScreenListSheet(
               .nestedScroll(nestedScrollConnection), // Add nested scroll modifier
       state = lazyListState // Attach LazyListState to track scroll position
       ) {
-        items(events) { event ->
+        items(events.sortedBy { it.startsAtTimestamp }) { event ->
           EventCard(
               event = event,
               onClick = { onEventClick(event) }, // Use the provided onJoinClick callback

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/HomeScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/HomeScreen.kt
@@ -252,7 +252,7 @@ fun HomeScreen(
                             }
                       }
                     } else {
-                      items(closestEventsState.value) { event ->
+                      items(closestEventsState.value.sortedBy { it.startsAtTimestamp }) { event ->
                         EventCard(
                             event,
                             onClick = { navObject.navigateTo(Route.EVENT_SCREEN + "/${event.id}") })

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/HomeScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/HomeScreen.kt
@@ -252,7 +252,7 @@ fun HomeScreen(
                             }
                       }
                     } else {
-                      items(closestEventsState.value.sortedBy { it.startsAtTimestamp }) { event ->
+                      items(closestEventsState.value) { event ->
                         EventCard(
                             event,
                             onClick = { navObject.navigateTo(Route.EVENT_SCREEN + "/${event.id}") })

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/MyEventsScreen.kt
@@ -66,7 +66,8 @@ fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsView
                         modifier = Modifier.padding(16.dp).testTag("empty create event list"))
                   }
                 } else {
-                  items(uiState.createdEvents.values.toList()) { event ->
+                  items(uiState.createdEvents.values.toList().sortedBy { it.startsAtTimestamp }) {
+                      event ->
                     EventCard(event = event, modifier = Modifier.testTag("a created event")) {
                       navObject.navigateTo(Route.EVENT_SCREEN + "/${event.id}")
                     }
@@ -86,7 +87,8 @@ fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsView
                         modifier = Modifier.padding(16.dp).testTag("empty join event list"))
                   }
                 } else {
-                  items(uiState.joinedEvents.values.toList()) { event ->
+                  items(uiState.joinedEvents.values.toList().sortedBy { it.startsAtTimestamp }) {
+                      event ->
                     EventCard(event = event, modifier = Modifier.testTag("a joined event")) {
                       navObject.navigateTo(Route.EVENT_SCREEN + "/${event.id}")
                     }
@@ -108,11 +110,15 @@ fun MyEventsScreen(navObject: NavigationActions, myEventsViewModel: MyEventsView
                         modifier = Modifier.padding(16.dp).testTag("empty_past_events_list"))
                   }
                 } else {
-                  items(uiState.pastEvents.values.toList()) { event ->
-                    EventCard(event = event, modifier = Modifier.testTag("past_event_card")) {
-                      navObject.navigateTo(Route.EVENT_SCREEN + "/${event.id}")
-                    }
-                  }
+                  items(
+                      uiState.pastEvents.values
+                          .toList()
+                          .sortedBy { it.endsAtTimestamp }
+                          .reversed()) { event ->
+                        EventCard(event = event, modifier = Modifier.testTag("past_event_card")) {
+                          navObject.navigateTo(Route.EVENT_SCREEN + "/${event.id}")
+                        }
+                      }
                 }
               }
             }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/SuppliesPanel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/SuppliesPanel.kt
@@ -64,7 +64,7 @@ fun SuppliesPanel(eventViewModel: EventViewModel) {
         Spacer(modifier = Modifier.height(16.dp))
 
         LazyColumn {
-          items(uiState.supplies.values.toList()) { item ->
+          items(uiState.supplies.values.toList().reversed()) { item ->
             ListItem(
                 headlineContent = {
                   Text(

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/event/details/supplies/SuppliesScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -34,7 +33,6 @@ import com.monkeyteam.chimpagne.ui.navigation.NavigationActions
 import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
 import com.monkeyteam.chimpagne.viewmodels.EventViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SuppliesScreen(
     navObject: NavigationActions,
@@ -109,7 +107,7 @@ fun SuppliesScreen(
     if (supplyList.isNotEmpty()) {
       Text(text = listTitle, modifier = Modifier.padding(12.dp, 8.dp))
       LazyColumn(modifier = Modifier.testTag(testTag)) {
-        supplyList.forEach { supply ->
+        supplyList.reversed().forEach { supply ->
           item {
             SupplyCard(supply = supply) {
               displayedSupply = supply


### PR DESCRIPTION
This PR is meant to fix:
- issue #204, where now when creating a new supplies they appear on top of the displayed supplies. You can see this change from the create event screen (3rd panel) or from the supplies screen for an existing event.
- issue #129, where now when fetching events, they are always ordered by date. You can see this change from the MyEvents screen or in the FindEvents screen bottom sheet.