### PR TITLE
Delete Profile Picture, when deleting Account

### DIFF
--- a/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/model/database/ChimpagneAccountManager.kt
@@ -76,7 +76,7 @@ class ChimpagneAccountManager(
     accounts
         .document(userUid)
         .delete()
-        .addOnSuccessListener { onSuccess() }
+        .addOnSuccessListener { deleteProfilePicture(userUid, { onSuccess() }, { onFailure(it) }) }
         .addOnFailureListener { onFailure(it) }
   }
 
@@ -175,6 +175,18 @@ class ChimpagneAccountManager(
             onSuccess(downloadUrl.toString())
           }
         }
+        .addOnFailureListener { onFailure(it) }
+  }
+
+  fun deleteProfilePicture(
+      userUid: ChimpagneAccountUID,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    profilePictures
+        .child(userUid)
+        .delete()
+        .addOnSuccessListener { onSuccess() }
         .addOnFailureListener { onFailure(it) }
   }
 


### PR DESCRIPTION
My first PR for delete account: #238 didn't delete the picture of the user from the database. This is fixed in here