### PR TITLE
Resolve Issue #243 (Location Should be mandatory when creating/Editing) an event

### DIFF
--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/end2end/EventCreation.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/end2end/EventCreation.kt
@@ -1,10 +1,13 @@
 package com.monkeyteam.chimpagne.end2end
 
 import android.Manifest
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -17,7 +20,9 @@ import androidx.test.rule.GrantPermissionRule
 import com.google.firebase.auth.FirebaseAuth
 import com.monkeyteam.chimpagne.model.database.ChimpagneAccount
 import com.monkeyteam.chimpagne.model.database.Database
+import com.monkeyteam.chimpagne.model.location.Location
 import com.monkeyteam.chimpagne.newtests.initializeTestDatabase
+import com.monkeyteam.chimpagne.ui.components.LocationSelector
 import com.monkeyteam.chimpagne.ui.navigation.NavigationGraph
 import com.monkeyteam.chimpagne.ui.navigation.Route
 import com.monkeyteam.chimpagne.viewmodels.AccountViewModel
@@ -47,6 +52,15 @@ class EventCreation {
   @get:Rule
   val mRuntimePermissionRule: GrantPermissionRule =
       GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION)
+
+  @Composable
+  fun LocationSelectorTestView(
+      selectedLocation: Location?,
+      updateSelectedLocation: (Location) -> Unit
+  ) {
+    LocationSelector(
+        selectedLocation = selectedLocation, updateSelectedLocation = updateSelectedLocation)
+  }
 
   @Before
   fun init() {
@@ -82,6 +96,12 @@ class EventCreation {
       navController.currentDestination?.route == Route.EVENT_CREATION_SCREEN
     }
     composeTestRule.onNodeWithTag("add_a_title").performTextInput(eventName)
+    composeTestRule.onNodeWithText("Search for a location").performTextInput("New York")
+    composeTestRule.onNodeWithTag("SearchIcon").performClick()
+    composeTestRule.waitUntil(timeout) {
+      composeTestRule.onAllNodesWithTag("location_possibility").fetchSemanticsNodes().isNotEmpty()
+    }
+    composeTestRule.onAllNodesWithTag("location_possibility").onFirst().performClick()
     composeTestRule.onNodeWithTag("next_button").performClick()
     composeTestRule.onNodeWithTag("next_button").performClick()
     composeTestRule.onNodeWithTag("next_button").performClick()

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -515,4 +515,12 @@ class EventViewModelTests {
         EventViewModel.eventInputValidityToString(EventInputValidity.INVALID_DATES, context)
     assertEquals(context.getString(R.string.invalid_dates), result)
   }
+
+    @Test
+    fun testEmptyLocation() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val result =
+            EventViewModel.eventInputValidityToString(EventInputValidity.EMPTY_LOCATION, context)
+        assertEquals(context.getString(R.string.location_should_not_be_empty), result)
+    }
 }

--- a/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
+++ b/app/src/androidTest/java/com/monkeyteam/chimpagne/newtests/viewmodels/EventViewModelTests.kt
@@ -516,11 +516,11 @@ class EventViewModelTests {
     assertEquals(context.getString(R.string.invalid_dates), result)
   }
 
-    @Test
-    fun testEmptyLocation() {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val result =
-            EventViewModel.eventInputValidityToString(EventInputValidity.EMPTY_LOCATION, context)
-        assertEquals(context.getString(R.string.location_should_not_be_empty), result)
-    }
+  @Test
+  fun testEmptyLocation() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val result =
+        EventViewModel.eventInputValidityToString(EventInputValidity.EMPTY_LOCATION, context)
+    assertEquals(context.getString(R.string.location_should_not_be_empty), result)
+  }
 }

--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/LocationSelector.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/LocationSelector.kt
@@ -125,7 +125,8 @@ fun LocationSelector(
                     Text(
                         text = location.name,
                         modifier =
-                            Modifier.clickable {
+                            Modifier.testTag("location_possibility")
+                                .clickable {
                                   locationQuery = location.name
                                   searchCompleted = true
                                   showSearchBar = false

--- a/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/viewmodels/EventViewModel.kt
@@ -29,7 +29,8 @@ import kotlinx.coroutines.launch
 enum class EventInputValidity {
   INVALID_TITLE,
   INVALID_SOCIAL_MEDIA_LINKS,
-  INVALID_DATES
+  INVALID_DATES,
+  EMPTY_LOCATION
 }
 
 class EventViewModel(
@@ -57,6 +58,8 @@ class EventViewModel(
         EventInputValidity.INVALID_SOCIAL_MEDIA_LINKS ->
             context.getString(R.string.invalid_social_media_links)
         EventInputValidity.INVALID_DATES -> context.getString(R.string.invalid_dates)
+        EventInputValidity.EMPTY_LOCATION ->
+            context.getString(R.string.location_should_not_be_empty)
       }
     }
   }
@@ -64,6 +67,7 @@ class EventViewModel(
   private fun validateEventInputs(): EventInputValidity? {
     return when {
       _uiState.value.title.isEmpty() -> EventInputValidity.INVALID_TITLE
+      _uiState.value.location.name.isEmpty() -> EventInputValidity.EMPTY_LOCATION
       _uiState.value.startsAtCalendarDate.after(_uiState.value.endsAtCalendarDate) ||
           _uiState.value.startsAtCalendarDate.equals(_uiState.value.endsAtCalendarDate) ->
           EventInputValidity.INVALID_DATES

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -163,7 +163,8 @@
     <string name="account_last_name">Nom</string>
     <string name="account_logout">Se déconnecter</string>
 
-    <string name="title_should_not_be_empty">Le titre de l\'événement ne peut être vide</string>
+    <string name="title_should_not_be_empty">Le titre de l\'événement est requis</string>
+    <string name="location_should_not_be_empty">La Localisation est requise</string>
     <string name="invalid_dates">Dates invalides</string>
     <string name="invalid_social_media_links">Liens de médias sociaux invalides</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,7 +170,8 @@
     <string name="account_last_name">Last Name</string>
     <string name="account_logout">Log out</string>
 
-    <string name="title_should_not_be_empty">The event title should not be empty</string>
+    <string name="title_should_not_be_empty">The Event Title should not be empty</string>
+    <string name="location_should_not_be_empty">The Location should not be empty</string>
     <string name="invalid_dates">Invalid dates</string>
     <string name="invalid_social_media_links">Invalid social media links</string>
     <!-- DateRangeSelector -->


### PR DESCRIPTION
I have fixed issue #243 . Now users are obligated to enter a location when editing/creating events. I needed to modify the end2end test "EventCreation" because it was failing due to the fixed issue.