### PR TITLE
previous location now displayed when editing event

### DIFF
--- a/app/src/main/java/com/monkeyteam/chimpagne/ui/components/LocationSelector.kt
+++ b/app/src/main/java/com/monkeyteam/chimpagne/ui/components/LocationSelector.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,6 +51,12 @@ fun LocationSelector(
   var showSearchBar by remember { mutableStateOf(false) }
   var searchCompleted by remember { mutableStateOf(false) }
   var possibleLocations by remember { mutableStateOf(emptyList<Location>()) }
+
+  LaunchedEffect(selectedLocation) {
+    if (selectedLocation != null) {
+      locationQuery = selectedLocation.name
+    }
+  }
 
   val launchSearch = {
     if (locationQuery.isNotEmpty()) {


### PR DESCRIPTION
When editing an event, the previous location was not shown in the search field. This is now fixed

Before:

https://github.com/Chimpagne/ChimpagneApp/assets/79521990/eeb626e3-8f39-43df-a045-e5ba063188cb

After:

https://github.com/Chimpagne/ChimpagneApp/assets/79521990/690ffbfb-35cd-4081-93de-13d35d2a7af5

